### PR TITLE
Add full definitions for penal code entries

### DIFF
--- a/json/gtaw_penal_code.json
+++ b/json/gtaw_penal_code.json
@@ -1,1985 +1,2008 @@
 {
-	"000": {
-		"id": "000",
-		"charge": "UNKNOWN CHARGE",
-		"definition": "?",
-		"type": "?",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": false,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+    "000": {
+        "id": "000",
+        "charge": "UNKNOWN CHARGE",
+        "definition": "?",
+        "type": "?",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": false,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 0,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"001": {
-		"id": "001",
-		"charge": "Treason",
-		"definition": "Any person who, owing allegiance to the United States, levies war against them or adheres to their enemies, giving them aid and comfort within the United States or elsewhere.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "001": {
+        "id": "001",
+        "charge": "Treason",
+        "definition": "Any person who, owing allegiance to the United States, levies war against them or adheres to their enemies, giving them aid and comfort within the United States or elsewhere.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "Required Court Case"
-	},
-	"002": {
-		"id": "002",
-		"charge": "Espionage",
-		"definition": "Any person who knowingly communicates, transmits, or attempts to transmit or otherwise makes available to an unauthorized person or uses in any manner prejudicial to the safety or interest of the United States or for the benefit of a foreign country any classified information concerning defense information, healthcare installations and communication intelligence of the United States.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Required Court Case"
+    },
+    "002": {
+        "id": "002",
+        "charge": "Espionage",
+        "definition": "Any person who knowingly communicates, transmits, or attempts to transmit or otherwise makes available to an unauthorized person or uses in any manner prejudicial to the safety or interest of the United States or for the benefit of a foreign country any classified information concerning defense information, healthcare installations and communication intelligence of the United States",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "Required Court Case"
-	},
-	"003": {
-		"id": "003",
-		"charge": "Domestic Terrorism",
-		"definition": "a) Any person who, with intent to intimidate or coerce a civilian population, or to influence a policy of a government, or any segment thereof, or to affect the conduct of a unit of government, commits or attempts to commit an act that would result in great bodily injury or death.\n\nb) Any person who, with intent to intimidate or coerce a civilian population, or to influence a policy of a government, or any segment thereof, or to affect the conduct of a unit of government, knowingly and willfully encourages, incites, or solicits another person to commit an act that would result in great bodily injury or death.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Required Court Case"
+    },
+    "003": {
+        "id": "003",
+        "charge": "Domestic Terrorism",
+        "definition": "a) Any person who, with intent to intimidate or coerce a civilian population, or to influence a policy of a government, or any segment thereof, or to affect the conduct of a unit of government, commits or attempts to commit an act that would result in great bodily injury or death.\n\nb) Any person who, with intent to intimidate or coerce a civilian population, or to influence a policy of a government, or any segment thereof, or to affect the conduct of a unit of government, knowingly and willfully encourages, incites, or solicits another person to commit an act that would result in great bodily injury or death.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "Required Court Case"
-	},
-	"004": {
-		"id": "004",
-		"charge": "Domestic Terror Threats",
-		"definition": "Any person who willfully threatens to commit a crime that will result in great bodily injury or death to another person, to intimidate or coerce a civilian population with specific intent that the statement, made verbally or in writing is to be taken as a threat.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9999,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Required Court Case"
+    },
+    "004": {
+        "id": "004",
+        "charge": "Domestic Terror Threats",
+        "definition": "Any person who willfully threatens to commit a crime that will result in great bodily injury or death to another person, to intimidate or coerce a civilian population with specific intent that the statement, made verbally or in writing is to be taken as a threat.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9999,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "Required Court Case"
-	},
-	"101": {
-		"id": "101",
-		"charge": "Tax Evasion",
-		"definition": "a) Any person who knowingly, within the time required by law, fails to make, sign, rectify or file any return with the state, city, or any subdivisions thereof or with any public office.\n\nb) Any person who, with intent to avoid any tax, makes, renders, signs, or verifies any false or fraudulent return or statement or supplies any false or fraudulent information to the state, city, or any subdivisions thereof or with any public office.\n\nc) Any person who performs any licensed activity without a valid license and any subsequent operations denies taxes to the state, city, or any subdivisions thereof or with any public office.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 5000,
-			"2": 10000,
-			"3": 15000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Required Court Case"
+    },
+    "101": {
+        "id": "101",
+        "charge": "Tax Evasion",
+        "definition": "a) Any person who knowingly, within the time required by law, fails to make, sign, rectify or file any return with the state, city, or any subdivisions thereof or with any public office.\n\nb) Any person who, with intent to avoid any tax, makes, renders, signs, or verifies any false or fraudulent return or statement or supplies any false or fraudulent information to the state, city, or any subdivisions thereof or with any public office.\n\nc) Any person who performs any licensed activity without a valid license and any subsequent operations denies taxes to the state, city, or any subdivisions thereof or with any public office.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 5000,
+            "2": 10000,
+            "3": 15000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"102": {
-		"id": "102",
-		"charge": "Voter Fraud",
-		"definition": "Any person who attempts to add, subtract or delete votes or attempts to falsify the results of an election or otherwise attempts to dissuade or influence the election voting through coercion, persuasion, promises, bribes, threats, violence, fraud, or trickery.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "102": {
+        "id": "102",
+        "charge": "Voter Fraud",
+        "definition": "Any person who attempts to add, subtract or delete votes or attempts to falsify the results of an election or otherwise attempts to dissuade or influence the election voting through coercion, persuasion, promises, bribes, threats, violence, fraud, or trickery.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 60000
         },
-		"extra": "N/A"
-	},
-	"103": {
-		"id": "103",
-		"charge": "Corruption of Public Office",
-		"definition": "Any person who, while employed by a municipal, county, or state level agency or organization, or any person acting in concert with a public servant’s act with the intent to defraud the government, or any segment thereof to obtain property, actual service, resources or preferential treatment by false or fraudulent pretenses, representations or promises.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "103": {
+        "id": "103",
+        "charge": "Corruption of Public Office",
+        "definition": "Any person who, while employed by a municipal, county, or state level agency or organization, or any person acting in concert with a public servant’s act with the intent to defraud the government, or any segment thereof to obtain property, actual service, resources or preferential treatment by false or fraudulent pretenses, representations or promises.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"104": {
-		"id": "104",
-		"charge": "Neglect of Public Duty",
-		"definition": "Any person who, while employed by a municipal, county, or state level agency, organization or other governmental instrumentality, either willfully or negligently refrains from performing a duty which is imposed upon him by law or is clearly inherent in the nature of his office, leading to the deterioration of public safety, risk of physical harm, actual physical harm, or a violation of this code.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 3,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "104": {
+        "id": "104",
+        "charge": "Neglect of Public Duty",
+        "definition": "Any person who, while employed by a municipal, county, or state level agency, organization or other governmental instrumentality, either willfully or negligently refrains from performing a duty which is imposed upon him by law or is clearly inherent in the nature of his office, leading to the deterioration of public safety, risk of physical harm, actual physical harm, or a violation of this code.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 3,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "N/A"
-	},
-	"105": {
-		"id": "105",
-		"charge": "Bribery of a Public Official",
-		"definition": "Any person who confers, or offers, or agrees to confer money, goods, services, benefits, or anything of value to a public employee to improperly influence that individual’s official action, opinion, judgment, decision, or exercise of discretion as a public servant.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "105": {
+        "id": "105",
+        "charge": "Bribery of a Public Official",
+        "definition": "Any person who confers, or offers, or agrees to confer money, goods, services, benefits, or anything of value to a public employee to improperly influence that individual’s official action, opinion, judgment, decision, or exercise of discretion as a public servant.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 300000
         },
-		"extra": "N/A"
-	},
-	"106": {
-		"id": "106",
-		"charge": "Incitement To Riot",
-		"definition": "Any person who, with the intent to cause a riot, engages in tumultuous or violent conduct that urges a riot, or urges others to commit acts of force, violence, or destruction of property under circumstances that create public alarm.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "106": {
+        "id": "106",
+        "charge": "Incitement To Riot",
+        "definition": "Any person who, with the intent to cause a riot, engages in tumultuous or violent conduct that urges a riot, or urges others to commit acts of force, violence, or destruction of property under circumstances that create public alarm.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"107": {
-		"id": "107",
-		"charge": "Unlawful Assembly",
-		"definition": "a) Any person who refuses to disperse or leave a public facility or ground without possessing a valid permit and has been ordered to leave by law enforcement.\n\nb) Any person who knowingly assembles with two or more other persons with the intent to engage in conduct that would violate any criminal statute, or engage in conduct that recklessly creates a risk of public alarm, inconvenience, or annoyance, except peaceful gatherings for the purpose of lawful protest, expression of free speech, or any assembly conducted with a valid permit.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "107": {
+        "id": "107",
+        "charge": "Unlawful Assembly",
+        "definition": "a) Any person who refuses to disperse or leave a public facility or ground without possessing a valid permit and has been ordered to leave by law enforcement.\n\nb) Any person who knowingly assembles with two or more other persons with the intent to engage in conduct that would violate any criminal statute, or engage in conduct that recklessly creates a risk of public alarm, inconvenience, or annoyance, except peaceful gatherings for the purpose of lawful protest, expression of free speech, or any assembly conducted with a valid permit.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"108": {
-		"id": "108",
-		"charge": "Tampering with Evidence",
-		"definition": "Any person who knowingly alters, modifies, manufactures, plants, places, destroys, damages, conceals, or moves anything used as evidence with the intent to prevent, mislead or hinder a legal proceeding or otherwise produce a deceptive effect at such proceeding.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 4,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "108": {
+        "id": "108",
+        "charge": "Tampering with Evidence",
+        "definition": "Any person who knowingly alters, modifies, manufactures, plants, places, destroys, damages, conceals, or moves anything used as evidence with the intent to prevent, mislead or hinder a legal proceeding or otherwise produce a deceptive effect at such proceeding.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 4,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 150000
         },
-        
-		"extra": "N/A"
-	},
-	"109": {
-		"id": "109",
-		"charge": "Intimidating a Witness or Victim",
-		"definition": "Any person who knowingly and maliciously prevents or dissuades or who attempts to prevent or dissuade a witness or victim, from attending or providing testimony at any judicial proceeding or inquiry, or making a report that could lead to criminal action being taken.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 5,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "109": {
+        "id": "109",
+        "charge": "Intimidating a Witness or Victim",
+        "definition": "Any person who knowingly and maliciously prevents or dissuades or who attempts to prevent or dissuade a witness or victim, from attending or providing testimony at any judicial proceeding or inquiry, or making a report that could lead to criminal action being taken.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 5,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"110": {
-		"id": "110",
-		"charge": "Contempt of Court",
-		"definition": "a) Any person whose disorderly, contemptuous, or insolent behavior, committed during the sitting of a court, in its immediate view and presence directly tends to interrupt its proceedings or to impair the respect due to its authority.\n\nb) Any person who through the breach of the peace, noise, or other disturbance, directly tends to interrupt a court's proceedings.\n\nc) Any person who intentionally disobeys or resists the lawful process or other mandate of a court. This shall also extend to violations of court orders.\n\nd) Any person who knowingly publishes a false or grossly inaccurate report of a court's proceedings.\n\ne) Any person who refuses to pay their criminal or civil fines or fails to do so after being granted a payment plan for said fines.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 20000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "110": {
+        "id": "110",
+        "charge": "Contempt of Court",
+        "definition": "a) Any person whose disorderly, contemptuous, or insolent behavior, committed during the sitting of a court, in its immediate view and presence directly tends to interrupt its proceedings or to impair the respect due to its authority.\n\nb) Any person who through the breach of the peace, noise, or other disturbance, directly tends to interrupt a court's proceedings.\n\nc) Any person who intentionally disobeys or resists the lawful process or other mandate of a court. This shall also extend to violations of court orders.\n\nd) Any person who knowingly publishes a false or grossly inaccurate report of a court's proceedings.\n\ne) Any person who refuses to pay their criminal or civil fines or fails to do so after being granted a payment plan for said fines.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 20000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"111": {
-		"id": "111",
-		"charge": "Perjury",
-		"definition": "a) Any person who, having taken an oath that they will testify, declare, depose, or certify truly before any competent tribunal, officer, or in a court sitting willfully and contrary to the oath, states as true any material matter which they know to be false.\n\nb) Any person who, through written or spoken affidavit, knowingly supplies information that is false, incomplete, or willfully inaccurate, with intent to mislead or delay any process of court procedure.\n\nc) No person shall be convicted of perjury where proof of falsity rests solely upon contradiction by testimony of a single person other than the defendant. Proof of falsity may be established by direct or indirect evidence.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 5,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "111": {
+        "id": "111",
+        "charge": "Perjury",
+        "definition": "a) Any person who, having taken an oath that they will testify, declare, depose, or certify truly before any competent tribunal, officer, or in a court sitting willfully and contrary to the oath, states as true any material matter which they know to be false.\n\nb) Any person who, through written or spoken affidavit, knowingly supplies information that is false, incomplete, or willfully inaccurate, with intent to mislead or delay any process of court procedure.\n\nc) No person shall be convicted of perjury where proof of falsity rests solely upon contradiction by testimony of a single person other than the defendant. Proof of falsity may be established by direct or indirect evidence.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 5,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 80000
         },
-		"extra": "N/A"
-	},
-	"112F": {
-		"id": "112F",
-		"charge": "Obstruction of Public Duty (Felony)",
-		"definition": "(a) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to cause grievous bodily harm, or death, to another.\n\n(b) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to cause serious damage to property which exceeds $50,000, or some other serious loss which exceeds $100,000, or minor bodily harm to another.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 25
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 4,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 3,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "112F": {
+        "id": "112F",
+        "charge": "Obstruction of Public Duty (Felony)",
+        "definition": "(a) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to cause grievous bodily harm, or death, to another.\n\n(b) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to cause serious damage to property which exceeds $50,000, or some other serious loss which exceeds $100,000, or minor bodily harm to another.\n\n(c) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with\nthe intent to:\n\n(i) cause some loss amounting to no more than $50,000, or\n(ii) subvert, or cause another to subvert, public order.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 25
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 4,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 3,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "For any violation(s) of provision (a) of this offense shall be liable under a Class A felony.\n\nFor any violation(s) of provision (b) of this offense shall be liable under a Class B felony."
-	},
-	"112M": {
-		"id": "112M",
-		"charge": "Obstruction of Public Duty (Misdemeanor)",
-		"definition": "(c) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to:\n(i) cause some loss amounting to no more than $50,000, or\n(ii) subvert, or cause another to subvert, public order.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 25
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 25
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For any violation(s) of provision (a) of this offense shall be liable under a Class A felony.\n\nFor any violation(s) of provision (b) of this offense shall be liable under a Class B felony."
+    },
+    "112M": {
+        "id": "112M",
+        "charge": "Obstruction of Public Duty (Misdemeanor)",
+        "definition": "(a) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to cause grievous bodily harm, or death, to another.\n\n(b) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with the intent to cause serious damage to property which exceeds $50,000, or some other serious loss which exceeds $100,000, or minor bodily harm to another.\n\n(c) Any person who without a lawful excuse, through the use of coercion, violence, or by using means meant to delay the administration of public justice or interfere with the safety of a bystander or officer, willfully obstruct or delay a public servant in the performance of their duties, with\nthe intent to:\n\n(i) cause some loss amounting to no more than $50,000, or\n(ii) subvert, or cause another to subvert, public order.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 25
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 25
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "For any violation(s) of provision (c) of this offense shall be liable under a Class C misdemeanor."
-	},
-	"113M": {
-		"id": "113M",
-		"charge": "Obstructing a Peace Officer's Animal (Misdemeanor)",
-		"definition": "a) Any person who willfully and maliciously, and with no legal justification, interferes with or obstructs any animal being used by a peace officer in the discharge or attempted discharge of their duties by frightening, teasing, agitating, harassing, or hindering the animal.\n\nb) Any person who willfully with no legal justification, strikes, beats, kicks, cuts, stabs, shoots, poisons, or otherwise injures a peace officer's animal that is working at the supervision of a peace officer.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 12,
-			"min": 0			
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For any violation(s) of provision (c) of this offense shall be liable under a Class C misdemeanor."
+    },
+    "113M": {
+        "id": "113M",
+        "charge": "Obstructing a Peace Officer's Animal (Misdemeanor)",
+        "definition": "a) Any person who willfully and maliciously, and with no legal justification, interferes with or obstructs any animal being used by a peace officer in the discharge or attempted discharge of their duties by frightening, teasing, agitating, harassing, or hindering the animal.\n\nb) Any person who willfully with no legal justification, strikes, beats, kicks, cuts, stabs, shoots, poisons, or otherwise injures a peace officer's animal that is working at the supervision of a peace officer.\n\nc) Any person who, in violation of provisions (a) and (b), and with intent to inflict that injury or death, personally causes the death, or serious physical injury including loss or impairment of function of any bodily member or serious crippling.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 12,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "For any violation(s) of provision (a) and (b) this offense shall be liable under a Class B misdemeanor."
-	},
-	"113F": {
-		"id": "113F",
-		"charge": "Obstructing a Peace Officer's Animal (Felony)",
-		"definition": "a) Any person who willfully and maliciously, and with no legal justification, interferes with or obstructs any animal being used by a peace officer in the discharge or attempted discharge of their duties by frightening, teasing, agitating, harassing, or hindering the animal.\n\nb) Any person who willfully with no legal justification, strikes, beats, kicks, cuts, stabs, shoots, poisons, or otherwise injures a peace officer's animal that is working at the supervision of a peace officer.\n\nc) Any person who, in violation of provisions (a) and (b), and with intent to inflict that injury or death, personally causes the death, or serious physical injury including loss or impairment of function of any bodily member or serious crippling.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 3,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For any violation(s) of provision (a) and (b) this offense shall be liable under a Class B misdemeanor."
+    },
+    "113F": {
+        "id": "113F",
+        "charge": "Obstructing a Peace Officer's Animal (Felony)",
+        "definition": "a) Any person who willfully and maliciously, and with no legal justification, interferes with or obstructs any animal being used by a peace officer in the discharge or attempted discharge of their duties by frightening, teasing, agitating, harassing, or hindering the animal.\n\nb) Any person who willfully with no legal justification, strikes, beats, kicks, cuts, stabs, shoots, poisons, or otherwise injures a peace officer's animal that is working at the supervision of a peace officer.\n\nc) Any person who, in violation of provisions (a) and (b), and with intent to inflict that injury or death, personally causes the death, or serious physical injury including loss or impairment of function of any bodily member or serious crippling.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 3,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "For any violation(s) of provision (c) this offense shall be liable under a Class A felony."
-	},
-	"114": {
-		"id": "114",
-		"charge": "Escape From Lawful Custody",
-		"definition": "Any person arrested, booked, charged, or convicted of a criminal offense, and who thereafter escapes from a county or city jail, prison, detention facility, community service, or the custody of a correctional officer in charge of them.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For any violation(s) of provision (c) this offense shall be liable under a Class A felony."
+    },
+    "114": {
+        "id": "114",
+        "charge": "Escape From Lawful Custody",
+        "definition": "Any person arrested, booked, charged, or convicted of a criminal offense, and who thereafter escapes from a county or city jail, prison, detention facility, community service, or the custody of a correctional officer in charge of them.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"115": {
-		"id": "115",
-		"charge": "Evading a Peace Officer",
-		"definition": "Any person who, while operating or upon entering a motor vehicle, or bicycle and with the intent to evade, willfully flees or otherwise attempts to elude a pursuing peace officer.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 10000,
-			"3": 20000
-		},
-		"impound": {
-			"1": 7,
-			"2": 7,
-			"3": 7
-		},
-		"suspension": {
-			"1": 7,
-			"2": 7,
-			"3": 7
-		},
+        "extra": "N/A"
+    },
+    "115": {
+        "id": "115",
+        "charge": "Evading a Peace Officer",
+        "definition": "Any person who, while operating or upon entering a motor vehicle, or bicycle and with the intent to evade, willfully flees or otherwise attempts to elude a pursuing peace officer.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 5000,
+            "2": 10000,
+            "3": 20000
+        },
+        "impound": {
+            "1": 7,
+            "2": 7,
+            "3": 7
+        },
+        "suspension": {
+            "1": 7,
+            "2": 7,
+            "3": 7
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"116": {
-		"id": "116",
-		"charge": "Resisting Arrest",
-		"definition": "Any person who intentionally delays, avoids, obstructs, prevents or attempts to prevent a peace officer from effecting the apprehension of himself or another person or in the discharge or attempted discharge of their duties. Shall extend to lying to a peace officer.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "116": {
+        "id": "116",
+        "charge": "Resisting Arrest",
+        "definition": "Any person who intentionally delays, avoids, obstructs, prevents or attempts to prevent a peace officer from effecting the apprehension of himself or another person or in the discharge or attempted discharge of their duties. Shall extend to lying to a peace officer.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"117": {
-		"id": "117",
-		"charge": "Lying to Government Agents",
-		"definition": "Any person who knowingly and willfully makes any materially false, fictitious or fraudulent statement or representation in any matter within the jurisdiction of the executive, legislative or judicial branch of the United States.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 8,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 10000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "117": {
+        "id": "117",
+        "charge": "Lying to Government Agents",
+        "definition": "Any person who knowingly and willfully makes any materially false, fictitious or fraudulent statement or representation in any matter within the jurisdiction of the executive, legislative or judicial branch of the United States.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 8,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 10000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 150000
         },
-		"extra": "N/A"
-	},
-	"118": {
-		"id": "118",
-		"charge": "Misuse of an Emergency Hotline",
-		"definition": "Any person who uses a government hotline, intended for either emergency or non-emergency assistance, with a purpose other than contacting the government with a legitimate concern or ushering for immediate assistance, including prank calls, jokes, or any other kind of distraction.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "118": {
+        "id": "118",
+        "charge": "Misuse of an Emergency Hotline",
+        "definition": "Any person who uses a government hotline, intended for either emergency or non-emergency assistance, with a purpose other than contacting the government with a legitimate concern or ushering for immediate assistance, including prank calls, jokes, or any other kind of distraction.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 90000
         },
-		"extra": "N/A"
-	},
-	"119": {
-		"id": "119",
-		"charge": "False Impersonation",
-		"definition": "a) Any person(s) who presents themselves as another or pretends to be a representative of some person or organization or impersonates  another  by  communication by  internet  website  or electronic means and does an act in such pretended capacity with intent to obtain a benefit or to injure or defraud another.\n\nb) Any person(s) who falsely represents themselves as a law enforcement officer, by wearing or displaying any uniform, badge, or other insignia that is commonly associated with such an officer, or by verbally or through their actions indicating that they are a law enforcement officer, with the intent to deceive another person into believing that they are a law enforcement officer and submitting to their authority.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 4,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "119": {
+        "id": "119",
+        "charge": "False Impersonation",
+        "definition": "a) Any person(s) who presents themselves as another or pretends to be a representative of some person or organization or impersonates  another  by  communication by  internet  website  or electronic  means  and does an act in such pretended capacity with intent to obtain a benefit or to injure or defraud another.\n\nb) Any person(s) who falsely represents themselves as a law enforcement officer, by wearing or displaying any uniform, badge, or other insignia that is commonly associated with such an officer, or by verbally or through their actions indicating that they are a law enforcement officer, with the intent to deceive another person into believing that they are a law enforcement officer and submitting to their authority.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 4,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 150000
         },
-		"extra": "N/A"
-	},
-	"120": {
-		"id": "120",
-		"charge": "Assault & Battery on a Government Worker",
-		"definition": "a) Any person who engages in willful and unlawful use of physical force upon a government worker.\nb) Any person who unlawfully attempts to commit a violent injury on a government worker or attempts to put a government worker they are in the presence of in reasonable fear of physical injury.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 5,
-			"B": 4,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "120": {
+        "id": "120",
+        "charge": "Assault & Battery on a Government Worker",
+        "definition": "a) Any person who engages in willful and unlawful use of physical force upon a government worker.\n\nb) Any person who unlawfully attempts to commit a violent injury on a government worker or attempts to put a government worker they are in the presence of in reasonable fear of physical injury.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 5,
+            "B": 4,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"121": {
-		"id": "121",
-		"charge": "Forgery",
-		"definition": "Any person who knowingly creates, completes or alters a written instrument, with the intent to defraud, deceive or injure another.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "121": {
+        "id": "121",
+        "charge": "Forgery",
+        "definition": "Any person who knowingly creates, completes or alters a written instrument, with the intent to defraud, deceive or injure another",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 350000
         },
-		"extra": "N/A"
-	},
-	"122M": {
-		"id": "122M",
-		"charge": "Fraud",
-		"definition": "a) Any person who knowingly, by any means of false representation by words, conduct, misleading allegation or by concealment of facts or written instruments attempts to defraud any other person of money, labor, or property, whether real or personal.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "122M": {
+        "id": "122M",
+        "charge": "Fraud",
+        "definition": "a) Any person who knowingly, by any means of false representation by words, conduct, misleading allegation or by concealment of facts or written instruments attempts to defraud any other person of money, labor, or property, whether real or personal. (M)\n\nb) Fraud resulting in the loss of $15,000 or more in monetary value will be considered a felony charge. (F)\n\nc) Any person having on display on their own vehicle, an identification plate registered to another vehicle owned by themselves. (F)",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "For any violation(s) of provision (a) this offense shall be liable under a Class C misdemeanor."
-	},
-	"122F": {
-		"id": "122F",
-		"charge": "Fraud",
-		"definition": "b) Fraud resulting in the loss of $15,000 or more in monetary value will be considered a felony charge.\n\nc) Any person having on display on their own vehicle, an identification plate registered to another vehicle owned by themselves.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For any violation(s) of provision (a) this offense shall be liable under a Class C misdemeanor."
+    },
+    "122F": {
+        "id": "122F",
+        "charge": "Fraud",
+        "definition": "a) Any person who knowingly, by any means of false representation by words, conduct, misleading allegation or by concealment of facts or written instruments attempts to defraud any other person of money, labor, or property, whether real or personal. (M)\n\nb) Fraud resulting in the loss of $15,000 or more in monetary value will be considered a felony charge. (F)\n\nc) Any person having on display on their own vehicle, an identification plate registered to another vehicle owned by themselves. (F)",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "For any violation(s) of provisions (b) or (c) this offense shall be liable under a Class C felony."
-	},
-	"123": {
-		"id": "123",
-		"charge": "Money Laundering",
-		"definition": "Any person who knowing that a property or monetary instruments represent the proceeds of criminal conduct, or the criminal sale of a controlled substance or weapons, or an act of terrorism, they conduct such financial transactions involving such proceeds or transports, transmits, or  transfers such monetary instruments with the intent to promote the carrying on of criminal conduct, knowing such transactions in whole or in part are designed to conceal or disguise the nature, the location, the source, the ownership or the control of the proceeds of criminal conduct, or avoid any transaction reporting requirement imposed by law.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 10000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For any violation(s) of provisions (b) or (c) this offense shall be liable under a Class C felony."
+    },
+    "123": {
+        "id": "123",
+        "charge": "Money Laundering",
+        "definition": "Any person who knowing that a property or monetary instruments represent the proceeds of criminal conduct, or the criminal sale of a controlled substance or weapons, or an act of terrorism, they conduct such financial transactions involving such proceeds or transports, transmits, or  transfers such monetary instruments with the intent to promote the carrying on of criminal conduct, knowing such transactions in whole or in part are designed to conceal or disguise the nature, the location, the source, the ownership or the control of the proceeds of criminal conduct, or avoid any transaction reporting requirement imposed by law.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 10000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": "The total value of the property involved in such financial transaction(s) dictates the charging guidelines, check the penal code."
-	},
-	"124": {
-		"id": "124",
-		"charge": "Defacing U.S. Currency",
-		"definition": "Any person who mutilates, cuts, defaces, disfigures, destroys, or perforates, or unites or cements together, or does any other thing to any bank bill or note with intent to render such bank bill or note unusable.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "The total value of the property involved in such financial transaction(s) dictates the charging guidelines, check the penal code."
+    },
+    "124": {
+        "id": "124",
+        "charge": "Defacing U.S. Currency",
+        "definition": "Any person who mutilates, cuts, defaces, disfigures, destroys, or perforates, or unites or cements together, or does any other thing to any bank bill or note with intent to render such bank bill or note unusable.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 350000
         },
-		"extra": "N/A"
-	},
-	"125": {
-		"id": "125",
-		"charge": "Disturbing the Peace",
-		"definition": "Any person(s) who engages in the following: fighting, violence, tumultuous or threatening behavior, unreasonable noise, abusive or obscene language/gestures in public.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "125": {
+        "id": "125",
+        "charge": "Disturbing the Peace",
+        "definition": "Any person(s) who engages in the following: fighting, violence, tumultuous or threatening behavior, unreasonable noise, abusive or obscene language/gestures in public.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"126": {
-		"id": "126",
-		"charge": "Racketeering",
-		"definition": "(a) It shall be unlawful for any person, group of persons, or organization(s), to knowingly engage or participate in, or conspire to engage or participate in, a pattern of racketeering activity, or through the collection of an unlawful debt, in the service of, association with or employment by any enterprise.\n\n(b) It shall be unlawful for any person through a pattern of criminal racketeering activity or through the collection of an unlawful debt to acquire or maintain, directly or indirectly, any interest in or control of any enterprise which is engaged in, or the activities of which affect, commercial activity.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 6,
-			"B": 5,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "126": {
+        "id": "126",
+        "charge": "Racketeering",
+        "definition": "(a) It shall be unlawful for any person, group of persons, or organization(s), to knowingly engage or participate in, or conspire to engage or participate in, a pattern of racketeering activity, or through the collection of an unlawful debt,  in the service of, association with or employment by any enterprise.\n\n(b) It shall be unlawful for any person through a pattern of criminal racketeering activity or through the collection of an unlawful debt to acquire or maintain, directly or indirectly, any interest in or control of any enterprise which is engaged in, or the activities of which affect, commercial activity.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 6,
+            "B": 5,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "'Enterprise' and all variations shall reference any coordinated, cooperative or collaborative activity undertaken by two or more persons associated by partnership, corporation, association, or other legal entity, and any union or group of individuals associated in fact but not necessarily through a legal entity with the intention of achieving financial or other material gain for the affiliated persons.\n\n'Racketeering activity' and all variations shall refer to any act involving the commission or attempted commission, a conspiracy to commit, threat to commit or to intentionally aid, solicit, order, coerce or intimidate another person to commit any unlawful activities defined within any of the following listed within the Penal Code.\n\n'Pattern of racketeering activity' and all variations shall refer to a minimum of two acts of racketeering activity, one of which occurred after the effective date of this section and the last of which occurred within twenty days after the commission of a prior act of racketeering activity, excluding any period of imprisonment.\n\n'Unlawful debt' and all variations shall reference any money or other things of value constituting principal or interest of a debt that is incurred or contracted in violation of any of the aforementioned activities."
-	},
-	"127": {
-		"id": "127",
-		"charge": "Violation of EFCE Act - Signal Jamming",
-		"definition": "a) Any person who knowingly and willfully—without legal justification or exemption—manufactures, produces, processes, or prepares a signal jammer which violates the provisions of the EFCE Act of 2023.\n\nb) Any person who knowingly and willfully—without legal justification or exemption—possesses, sells, distributes, advertises, or markets a signal jammer device which violations the provisions of the EFCE Act of 2023. Any individual charged with sales also qualifies to be charged with possession.\n\nc) Any person who knowingly and willfully—without legal justification or exemption—utilizes, employs, operates, or exploits a signal jammer to effect, manipulate, distort, or jam any communications system or alarm system which violates the provisions of the EFCE Act.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "'Enterprise' and all variations shall reference any coordinated, cooperative or collaborative activity undertaken by two or more persons associated by partnership, corporation, association, or other legal entity, and any union or group of individuals associated in fact but not necessarily through a legal entity with the intention of achieving financial or other material gain for the affiliated persons.\n\n'Racketeering activity' and all variations shall refer to any act involving the commission or attempted commission, a conspiracy to commit, threat to commit or to intentionally aid, solicit, order, coerce or intimidate another person to commit any unlawful activities defined within any of the following listed within the Penal Code.\n\n'Pattern of racketeering activity' and all variations shall refer to a minimum of two acts of racketeering activity, one of which occurred after the effective date of this section and the last of which occurred within twenty days after the commission of a prior act of racketeering activity, excluding any period of imprisonment.\n\n'Unlawful debt' and all variations shall reference any money or other things of value constituting principal or interest of a debt that is incurred or contracted in violation of any of the aforementioned activities."
+    },
+    "127": {
+        "id": "127",
+        "charge": "Violation of EFCE Act - Signal Jamming",
+        "definition": "a) Any person who knowingly and willfully—without legal justification or exemption—manufactures, produces, processes, or prepares a signal jammer which violates the provisions of the EFCE Act of 2023.\n\nb) Any person who knowingly and willfully—without legal justification or exemption—possesses, sells, distributes, advertises, or markets a signal jammer device which violations the provisions of the EFCE Act of 2023. Any individual charged with sales also qualifies to be charged with possession.\n\nc) Any person who knowingly and willfully—without legal justification or exemption—utilizes, employs, operates, or exploits a signal jammer to effect, manipulate, distort, or jam any communications system or alarm system which violates the provisions of the EFCE Act.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 75000
         },
-		"extra": "N/A"
-	},
-	"128": {
-		"id": "128",
-		"charge": "Violation of EFCE Act - Card Skimming",
-		"definition": "a) Any person who knowingly and willfully—without legal justification or exemption—manufactures, produces, processes, or prepares a card skimmer which violates the provisions of the EFCE Act.\n\nb) Any person who knowingly and willfully—without legal justification or exemption—possesses, sells, distributes, advertises, or markets a card skimmer device which violates the provisions of the EFCE Act. Any individual charged with sales also qualifies to be charged with possession.\n\nc) Any person who knowingly and willfully—without legal justification or exemption—possesses or uses a card skimmer to obtain financial information from individuals without their knowledge or consent, which violates the provisions of the EFCE Act.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "128": {
+        "id": "128",
+        "charge": "Violation of EFCE Act - Card Skimming",
+        "definition": "a) Any person who knowingly and willfully—without legal justification or exemption—manufactures, produces, processes, or prepares a card skimmer which violates the provisions of the EFCE Act.\n\nb) Any person who knowingly and willfully—without legal justification or exemption—possesses, sells, distributes, advertises, or markets a card skimmer device which violates the provisions of the EFCE Act. Any individual charged with sales also qualifies to be charged with possession.\n\nc) Any person who knowingly and willfully—without legal justification or exemption—possesses or uses a card skimmer to obtain financial information from individuals without their knowledge or consent, which violates the provisions of the EFCE Act.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 75000
         },
-		"extra": "N/A"
-	},
-	"129": {
-		"id": "129",
-		"charge": "Violation of EFCE Act - Vehicle Tracking",
-		"definition": "a) Any person who installs or plants an electronic tracking device on any vehicle or possession which violates the provisions of the EFCE Act.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 6
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "129": {
+        "id": "129",
+        "charge": "Violation of EFCE Act - Vehicle Tracking",
+        "definition": "a) Any person who installs or plants an electronic tracking device on any vehicle or possession which violates the provisions of the EFCE Act.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 6
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 75000
         },
-		"extra": "N/A"
-	},
-	"130": {
-		"id": "130",
-		"charge": "Rescuing A Prisoner",
-		"definition": "Any person who rescues or attempts to rescue, or aids another person in rescuing or attempting to rescue any prisoner from any prison, or prison road camp or any jail or county road camp, or from any officer or person having him or her in lawful custody.\n\nAny person who enters into a designated staff only zone as laid out by the Department of Corrections and Rehabilitation Authorization Act of 2023, without authorization from the Department of Corrections and Rehabilitation.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "130": {
+        "id": "130",
+        "charge": "Rescuing A Prisoner",
+        "definition": "Any person who rescues or attempts to rescue, or aids another person in rescuing or attempting to rescue any prisoner from any prison, or prison road camp or any jail or county road camp, or from any officer or person having him or her in lawful custody.\n\nAny person who enters into a designated staff only zone as laid out by the Department of Corrections and Rehabilitation Authorization Act of 2023, without authorization from the Department of Corrections and Rehabilitation.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"131": {
-		"id": "131",
-		"charge": "Bringing Contraband Into A Correctional Facility",
-		"definition": "Any person(s) who knowingly brings into any detention facility as defined in the DCRA Act of 2023,  any controlled substances as defined in Schedule I of Drug Enforcement and Prevention Act, or any device, contrivance, instrument, or paraphernalia intended to be used for unlawfully injecting or consuming any drug other than controlled substances, or any alcoholic beverages, or is in possession of any of the aforementioned contraband within the aforementioned locations, without having authority so to do by the rules of the Department of Corrections, or by the specific authorization of the warden, superintendent, jailer, or other person in charge of the facility. The highest category in possession determines the overall penalty.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 7,
-				"hours": 0,
-				"min": 0
-			},
-			"B": {
-				"days": 6,
-				"hours": 0,
-				"min": 0
-			},
-			"C": {
-				"days": 5,
-				"hours": 0,
-				"min": 0
-			},
-			"D": {
-				"days": 4,
-				"hours": 0,
-				"min": 0
-			},
-			"T": {
-				"days": 1,
-				"hours": 0,
-				"min": 0
-			},
-			"Alcohol": {
-				"days": 3,
-				"hours": 0,
-				"min": 0
-			},
-			"Instruments": {
-				"days": 5,
-				"hours": 0,
-				"min": 0
-			}
-		},
+        "extra": "N/A"
+    },
+    "131": {
+        "id": "131",
+        "charge": "Bringing Contraband Into A Correctional Facility",
+        "definition": "Any person(s) who knowingly brings into any detention facility as defined in the DCRA Act of 2023,  any controlled substances as defined in Schedule I of Drug Enforcement and Prevention Act, or any device, contrivance, instrument, or paraphernalia intended to be used for unlawfully injecting or consuming any drug other than controlled substances, or any alcoholic beverages, or is in possession of any of the aforementioned contraband within the aforementioned locations, without having authority so to do by the rules of the Department of Corrections, or by the specific authorization of the warden, superintendent, jailer, or other person in charge of the facility. The highest category in possession determines the overall penalty.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 7,
+                "hours": 0,
+                "min": 0
+            },
+            "B": {
+                "days": 6,
+                "hours": 0,
+                "min": 0
+            },
+            "C": {
+                "days": 5,
+                "hours": 0,
+                "min": 0
+            },
+            "D": {
+                "days": 4,
+                "hours": 0,
+                "min": 0
+            },
+            "T": {
+                "days": 1,
+                "hours": 0,
+                "min": 0
+            },
+            "Alcohol": {
+                "days": 3,
+                "hours": 0,
+                "min": 0
+            },
+            "Instruments": {
+                "days": 5,
+                "hours": 0,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "A": 45000,
+            "B": 37500,
+            "C": 30000,
+            "D": 22500,
+            "T": 8000,
+            "Alcohol": 25000,
+            "Instruments": 30000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": true,
@@ -2000,5296 +2023,5387 @@
                 "instruments": 250000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"A": 45000,
-			"B": 37500,
-			"C": 30000,
-			"D": 22500,
-			"T": 8000,
-			"Alcohol": 25000,
-			"Instruments": 30000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T",
-			"6": "Alcohol",
-			"7": "Instruments"
-		}
-	},
-	"132": {
-		"id": "132",
-		"charge": "Possession Of Communications In A Correctional Facility",
-		"definition": "(a) Any person in a local correctional facility who possesses a wireless communication device, including, but not limited to, a cellular telephone, pager, or wireless Internet device, who is not authorized to possess that item is guilty of a misdemeanor, punishable by a fine of not more than one thousand dollars ($1,000).\n\n(b) Money collected pursuant to this section shall be placed into the inmate welfare fund, as specified in Section 4025.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T",
+            "6": "Alcohol",
+            "7": "Instruments"
+        }
+    },
+    "132": {
+        "id": "132",
+        "charge": "Possession Of Communications In A Correctional Facility",
+        "definition": "(a) Any person in a local correctional facility who possesses a wireless communication device, including, but not limited to, a cellular telephone, pager, or wireless Internet device, who is not authorized to possess that item is guilty of a misdemeanor, punishable by a fine of not more than one thousand dollars ($1,000).\n\n(b) Money collected pursuant to this section shall be placed into the inmate welfare fund, as specified in Section 4025.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "N/A"
-	},
-	"133": {
-		"id": "133",
-		"charge": "Possession Of Tobacco In A Correctional Facility",
-		"definition": "(a) Any person housed in a local correctional facility who possesses any tobacco products in any form, including snuff products, smoking paraphernalia, any device that is intended to be used for ingesting or consuming tobacco, or any container or dispenser used for any of those products, is guilty of an infraction, punishable by a fine not exceeding two hundred fifty dollars ($250).\n\n(b) Subdivision (a) shall only apply to a person in a local correctional facility in a county in which the city council or county commission has adopted an ordinance or passed a resolution banning tobacco in its correctional facilities.\n\n(c) Money collected pursuant to this section shall be placed into the inmate welfare fund, as specified in Section 4025.",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "133": {
+        "id": "133",
+        "charge": "Possession Of Tobacco In A Correctional Facility",
+        "definition": "(a) Any person housed in a local correctional facility who possesses any tobacco products in any form, including snuff products, smoking paraphernalia, any device that is intended to be used for ingesting or consuming tobacco, or any container or dispenser used for any of those products, is guilty of an infraction, punishable by a fine not exceeding two hundred fifty dollars ($250).\n\n(b) Subdivision (a) shall only apply to a person in a local correctional facility in a county in which the city council or county commission has adopted an ordinance or passed a resolution banning tobacco in its correctional facilities.\n\n(c) Money collected pursuant to this section shall be placed into the inmate welfare fund, as specified in Section 4025.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"134": {
-		"id": "134",
-		"charge": "Possession Of Handcuff Keys In A Correctional Facility",
-		"definition": "(d) Any person housed in a local correctional facility who possesses a handcuff key who is not authorized to possess that item is guilty of a misdemeanor, punishable by imprisonment in a county jail not exceeding six months, or by a fine of up to one thousand dollars ($1,000), or by both that imprisonment and fine. As used in this subdivision, “handcuff key” means any device designed or intended to open or unlatch a handcuff.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "134": {
+        "id": "134",
+        "charge": "Possession Of Handcuff Keys In A Correctional Facility",
+        "definition": "(d) Any person housed in a local correctional facility who possesses a handcuff key who is not authorized to possess that item is guilty of a misdemeanor, punishable by imprisonment in a county jail not exceeding six months, or by a fine of up to one thousand dollars ($1,000), or by both that imprisonment and fine. As used in this subdivision, “handcuff key” means any device designed or intended to open or unlatch a handcuff.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "N/A"
-	},
-	"135": {
-		"id": "135",
-		"charge": "Murder of a Peace Officer Canine",
-		"definition": "Any person(s) who intentionally or knowingly, without lawful cause or justification, causes death upon a peace officer canine.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 15,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "135": {
+        "id": "135",
+        "charge": "Murder of a Peace Officer Canine",
+        "definition": "Any person(s) who intentionally or knowingly, without lawful cause or justification, causes death upon a peace officer canine.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 15,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"136": {
-		"id": "136",
-		"charge": "Aggravated Battery of a Peace Officer Canine",
-		"definition": "Any person(s) who intentionally or knowingly, without lawful cause or justification, causes great bodily harm or permanent disability upon a peace officer canine, with or without a deadly weapon.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "136": {
+        "id": "136",
+        "charge": "Aggravated Battery of a Peace Officer Canine",
+        "definition": "Any person(s) who intentionally or knowingly, without lawful cause or justification, causes great bodily harm or permanent disability upon a peace officer canine, with or without a deadly weapon.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"137": {
-		"id": "137",
-		"charge": "Battery of a Peace Officer Canine",
-		"definition": "Any person(s) who intentionally or knowingly maliciously touches, strikes, or causes bodily harm to a peace officer canine commits a misdemeanor without a deadly weapon.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "137": {
+        "id": "137",
+        "charge": "Battery of a Peace Officer Canine",
+        "definition": "Any person(s) who intentionally or knowingly maliciously touches, strikes, or causes bodily harm to a peace officer canine commits a misdemeanor without a deadly weapon.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"138": {
-		"id": "138",
-		"charge": "Obstruction of a Peace Officer Canine",
-		"definition": "Any person(s) who intentionally or knowingly maliciously harasses, teases, interferes with, or attempts to interfere with a peace officer canine while the working dog is in the performance of its duties commits a misdemeanor.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 25
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 25
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "138": {
+        "id": "138",
+        "charge": "Obstruction of a Peace Officer Canine",
+        "definition": "Any person(s) who intentionally or knowingly maliciously harasses, teases, interferes with, or attempts to interfere with a peace officer canine while the working dog is in the performance of its duties commits a misdemeanor.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 25
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 25
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"139": {
-		"id": "139",
-		"charge": "Misuse of the Mobile Data Computer",
-		"definition": "a) Any person(s) who, accesses, uses, alters, damages, deletes, or disrupts any function of an Mobile Data Computer (MDC) system, network, or data, with the intent to hinder or obstruct lawful operations, or to appropriate the MDC for personal, non-official, or criminal activities.\n\nb) Any person(s) who utilizes the MDC system or network to facilitate the commission of any crime, including fraud, theft, or unauthorized dissemination of personal or sensitive information.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 3,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "139": {
+        "id": "139",
+        "charge": "Misuse of the Mobile Data Computer",
+        "definition": "a) Any person(s) who, accesses, uses, alters, damages, deletes, or disrupts any function of an Mobile Data Computer (MDC) system, network, or data, with the intent to hinder or obstruct lawful operations, or to appropriate the MDC for personal, non-official, or criminal activities.\n\nb) Any person(s) who utilizes the MDC system or network to facilitate the commission of any crime, including fraud, theft, or unauthorized dissemination of personal or sensitive information.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 3,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"140": {
-		"id": "140",
-		"charge": "Unauthorized Sharing of Information from the Mobile Data Computer",
-		"definition": "a) Any person(s) who, outside their scope of employment, shares, disseminates, or publishes any information from the Mobile Data Computer (MDC) system, network, or data, regardless of its classification or sensitivity, not intended for public release or personal use.\n\nb) Any person(s) who negligently or intentionally shares, disseminates, or publishes any information from the MDC that compromises public safety, the integrity of investigations, or the security of the MDC system, including personal, contact, or property details.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 3,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "140": {
+        "id": "140",
+        "charge": "Unauthorized Sharing of Information from the Mobile Data Computer",
+        "definition": "a) Any person(s) who, outside their scope of employment, shares, disseminates, or publishes any information from the Mobile Data Computer (MDC) system, network, or data, regardless of its classification or sensitivity, not intended for public release or personal use.\n\nb) Any person(s) who negligently or intentionally shares, disseminates, or publishes any information from the MDC that compromises public safety, the integrity of investigations, or the security of the MDC system, including personal, contact, or property details.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 3,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"141": {
-		"id": "141",
-		"charge": "Unlawful Communication with an Inmate",
-		"definition": "Every person who, without the permission of the warden or other officer in charge of any detention facility as defined in the DCRA Act of 2024, communicates with any prisoner or person detained therein, or brings therein or takes therefrom any letter, writing, literature, or reading matter to or from any prisoner or person confined therein, is guilty of a misdemeanor.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 18,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "141": {
+        "id": "141",
+        "charge": "Unlawful Communication with an Inmate",
+        "definition": "Every person who, without the permission of the warden or other officer in charge of any detention facility as defined in the DCRA Act of 2024, communicates with any prisoner or person detained therein, or brings therein or takes therefrom any letter, writing, literature, or reading matter to or from any prisoner or person confined therein, is guilty of a misdemeanor.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 18,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"142M": {
-		"id": "142M",
-		"charge": "Failure to Appear at Court (Misdeamanor)",
-		"definition": "a) Every person who is charged with or convicted of the commission of a misdemeanor who is released from custody on his or her own recognizance and who in order to evade the process of the court willfully fails to appear as required, is guilty of a misdemeanor.",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "142M": {
+        "id": "142M",
+        "charge": "Failure to Appear at Court (Misdeamanor)",
+        "definition": "a) Every person who is charged with or convicted of the commission of a misdemeanor who is released from custody on his or her own recognizance and who in order to evade the process of the court willfully fails to appear as required, is guilty of a misdemeanor.\n\n(b) Every person who is charged with or convicted of the commission of a felony who is released from custody on his or her own recognizance and who in order to evade the process of the court willfully fails to appear as required, is guilty of a felony.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"142F": {
-		"id": "142F",
-		"charge": "Failure to Appear at Court (Felony)",
-		"definition": "(b) Every person who is charged with or convicted of the commission of a felony who is released from custody on his or her own recognizance and who in order to evade the process of the court willfully fails to appear as required, is guilty of a felony.",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "142F": {
+        "id": "142F",
+        "charge": "Failure to Appear at Court (Felony)",
+        "definition": "a) Every person who is charged with or convicted of the commission of a misdemeanor who is released from custody on his or her own recognizance and who in order to evade the process of the court willfully fails to appear as required, is guilty of a misdemeanor.\n\n(b) Every person who is charged with or convicted of the commission of a felony who is released from custody on his or her own recognizance and who in order to evade the process of the court willfully fails to appear as required, is guilty of a felony.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"201": {
-		"id": "201",
-		"charge": "Capital Murder",
-		"definition": "a) Any person who deliberately takes the life of a police officer, firefighter, paramedic, prosecutor, judge, juror, or other elected official while in the commission of their duty, or any witness in a criminal proceeding.\n\nb) Any person who uses especially heinous, atrocious, or cruel acts, manifesting exceptional depravity in the commission of murder in the first or second degree, or any murder that results from a murder-for-hire contract. In case of contract murders, both the killer and the person ordering the contract may be charged as a principal.\n\nc) Any person who purposely kills more than one individual and the murders are committed pursuant to the same scheme or course of conduct.\n\nd) Any incarcerated person who, while serving a life sentence, causes the death of another human being, through premeditated actions with malice aforethought.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 20,
-			"hours": 6,
-			"min": 0
-		},
-		"points": {
-			"A": 18,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "201": {
+        "id": "201",
+        "charge": "Capital Murder",
+        "definition": "a) Any person who deliberately takes the life of a police officer, firefighter, paramedic, prosecutor, judge, juror, or other elected official while in the commission of their duty, or any witness in a criminal proceeding.\n\nb) Any person who uses especially heinous, atrocious, or cruel acts, manifesting exceptional depravity in the commission of murder in the first or second degree, or any murder that results from a murder-for-hire contract. In case of contract murders, both the killer and the person ordering the contract may be charged as a principal.\n\nc) Any person who purposely kills more than one individual and the murders are committed pursuant to the same scheme or course of conduct.\n\nd) Any incarcerated person who, while serving a life sentence, causes the death of another human being, through premeditated actions with malice aforethought. (( Death penalty for this charge requires FM Permission ))",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 20,
+            "hours": 6,
+            "min": 0
+        },
+        "points": {
+            "A": 18,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "(( CK = Required Case ))\n(( Death penalty for this charge requires FM Permission ))"
-	},
-	"202": {
-		"id": "202",
-		"charge": "First Degree Murder",
-		"definition": "Any person who causes the death of another human being, through premeditated actions with malice aforethought.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 18,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 15,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-        "bail": {
-            "auto": false,
-            "cost": 0            
+        "extra": "(( CK = Required Case ))\n(( Death penalty for this charge requires FM Permission ))"
+    },
+    "202": {
+        "id": "202",
+        "charge": "First Degree Murder",
+        "definition": "Any person who causes the death of another human being, through premeditated actions with malice aforethought.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
         },
-		"extra": "(( CK = Required Case ))"
-	},
-	"203": {
-		"id": "203",
-		"charge": "Second Degree Murder",
-		"definition": "Any person who causes the death of another human being, through unpremeditated actions with malice aforethought.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 15,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 10,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 18,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 15,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "(( CK = Required Case ))"
-	},
-	"204": {
-		"id": "204",
-		"charge": "Voluntary Manslaughter",
-		"definition": "Any person who engages in the unlawful killing of a human being without malice upon a sudden quarrel or heat of passion, or based on an honest but unreasonable belief that deadly force is necessary (imperfect self-defense). ",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 10,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 7,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "(( CK = Required Case ))"
+    },
+    "203": {
+        "id": "203",
+        "charge": "Second Degree Murder",
+        "definition": "Any person who causes the death of another human being, through unpremeditated actions with malice aforethought.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 15,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 10,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
-            "cost": 0    
+            "cost": 0
         },
-		"extra": "N/A"
-	},
-	"205": {
-		"id": "205",
-		"charge": "Involuntary Manslaughter",
-		"definition": "Any person who engages in the unintentional killing of a human being without malice, either caused by an unlawful act that is not a felony, or a negligent act or failure to act.",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 7,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "(( CK = Required Case ))"
+    },
+    "204": {
+        "id": "204",
+        "charge": "Voluntary Manslaughter",
+        "definition": "Any person who engages in the unlawful killing of a human being without malice upon a sudden quarrel or heat of passion, or based on an honest but unreasonable belief that deadly force is necessary (imperfect self-defense).",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 10,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 7,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "bail": {
+            "auto": false,
+            "cost": 0
+        },
+        "extra": "N/A"
+    },
+    "205": {
+        "id": "205",
+        "charge": "Involuntary Manslaughter",
+        "definition": "Any person who engages in the unintentional killing of a human being without malice, either caused by an unlawful act that is not a felony, or a negligent act or failure to act.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 7,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 1500000
         },
-		"extra": "N/A"
-	},
-	"206": {
-		"id": "206",
-		"charge": "Assault",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "206": {
+        "id": "206",
+        "charge": "Assault",
+        "definition": "Any person who unlawfully attempts to commit a violent injury on the person of another or attempts to put another person they are in the presence of in reasonable fear of physical injury.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "N/A"
-	},
-	"207": {
-		"id": "207",
-		"charge": "Assault with a Deadly Weapon",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 3,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "207": {
+        "id": "207",
+        "charge": "Assault with a Deadly Weapon",
+        "definition": "a) Any person who unlawfully attempts to commit a violent injury on the person of another while in possession of a deadly weapon or instrument other than a firearm.\n\nb) Any person who unlawfully attempts to commit a violent injury on the person of another while in possession of a firearm.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 3,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "Check Penal Code for any additional provisions/altered sentencing guidelines"
-	},
-	"208": {
-		"id": "208",
-		"charge": "Battery",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 7,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Check Penal Code for any additional provisions/altered sentencing guidelines"
+    },
+    "208": {
+        "id": "208",
+        "charge": "Battery",
+        "definition": "Any person who engages in willful and unlawful use of physical force upon another individual.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 7,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 150000
         },
-		"extra": "N/A"
-	},
-	"209": {
-		"id": "209",
-		"charge": "Aggravated Battery",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 4,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "209": {
+        "id": "209",
+        "charge": "Aggravated Battery",
+        "definition": "Any person who engages in willful and unlawful use of physical force upon another individual, resulting in serious bodily injury.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 4,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"210": {
-		"id": "210",
-		"charge": "Kidnapping",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 7,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "210": {
+        "id": "210",
+        "charge": "Kidnapping",
+        "definition": "Any person who forcibly, or by any other means of instilling fear, steals or takes, or holds, detains, or unlawfully arrests any person with the intent to carry that person into another country, state, or county, or into another part of the same county.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 7,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"211": {
-		"id": "211",
-		"charge": "Human Trafficking",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 9,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "211": {
+        "id": "211",
+        "charge": "Human Trafficking",
+        "definition": "Any person who through coercion, violence, force or other illicit means deprives someone of their personal liberty with the intent to obtain forced labor or services from them or with the intent to violate San Andreas’ pimping and pandering laws.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 9,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"212": {
-		"id": "212",
-		"charge": "Unlawful Imprisonment",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "212": {
+        "id": "212",
+        "charge": "Unlawful Imprisonment",
+        "definition": "Any person who forcibly, or by any other means of instilling fear, holds, detains, restrains or unlawfully arrests another person.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"213": {
-		"id": "213",
-		"charge": "Torture",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 10,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "213": {
+        "id": "213",
+        "charge": "Torture",
+        "definition": "Any person who with the intent to cause cruel or extreme pain and suffering for the purpose of revenge, extortion, persuasion, or for any sadistic purpose, inflicts great bodily injury on another.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 10,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"214": {
-		"id": "214",
-		"charge": "Criminal Threats",
-		"type": "M",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "214": {
+        "id": "214",
+        "charge": "Criminal Threats",
+        "definition": "Any person who willfully threatens to commit a crime which would reasonably be believed to result in death or great bodily injury to another person and is made verbally, in writing, or by means of an electronic communication device, while not physically present of that individual.",
+        "type": "M",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": ""
-	},
-	"215": {
-		"id": "215",
-		"charge": "Robbery",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 4,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": ""
+    },
+    "215": {
+        "id": "215",
+        "charge": "Robbery",
+        "definition": "Any person involved in the unlawful taking of personal property in the possession of another, from his person, or immediate presence, and against his will by means of force or fear.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 4,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"216": {
-		"id": "216",
-		"charge": "Armed Robbery",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 5,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "216": {
+        "id": "216",
+        "charge": "Armed Robbery",
+        "definition": "Any person who unlawfully takes another’s property from his person or immediate possession when accomplished by force or fear with the use of a dangerous instrument or weapon of any type, improvised or not.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 5,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"217": {
-		"id": "217",
-		"charge": "Rape",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "217": {
+        "id": "217",
+        "charge": "Rape",
+        "definition": "Any person who engages in an act of sexual intercourse accomplished without the consent of the involved participant(s), one or more parties.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"218": {
-		"id": "218",
-		"charge": "Statutory Rape",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "218": {
+        "id": "218",
+        "charge": "Statutory Rape",
+        "definition": "Any person who engages in an act of consensual sexual intercourse accomplished with a person who is a minor under the age of 18 years.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"219": {
-		"id": "219",
-		"charge": "Sexual Battery",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"points": {
-			"A": 0,
-			"B": 4,
-			"C": 0
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "219": {
+        "id": "219",
+        "charge": "Sexual Battery",
+        "definition": "Any person who who touched an intimate part of another person against the will of that person for the purpose of sexual arousal, sexual gratification, or sexual abuse.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 4,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"220": {
-		"id": "220",
-		"charge": "Harassment",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "220": {
+        "id": "220",
+        "charge": "Harassment",
+        "definition": "Any person who engages in a course of conduct, or repeatedly commits acts directed at a specific person, which alarm or seriously alarm the person, and that serve no legitimate purpose after receiving verbal or written communication to cease. If written or verbal communication is not viable, criminal intent must be established.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
+        "extra": "N/A"
+    },
     "221": {
-		"id": "221",
-		"charge": "Domestic Violence",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "id": "221",
+        "charge": "Domestic Violence",
+        "definition": "Any person(s) who commits an act of battery, assault, assault with a deadly weapon, sexual battery, rape, torture, stalking, or any degree of murder against an intimate partner or family member as defined by statute.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 120000
         },
-		"extra": "N/A"
-	},
+        "extra": "N/A"
+    },
     "222": {
-		"id": "222",
-		"charge": "Assault with Caustic Chemicals",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "id": "222",
+        "charge": "Assault with Caustic Chemicals",
+        "definition": "Any person who willfully and maliciously places or throws, or causes to be placed or thrown, upon the person of another, any vitriol, corrosive acid, flammable substance, or caustic chemical of any nature, with the intent to injure the flesh or disfigure the body of that person.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"301": {
-		"id": "301",
-		"charge": "Arson",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": false,
-			"C": false
-		},
-		"points": {
-			"A": 5,
-			"B": 0,
-			"C": 0
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "301": {
+        "id": "301",
+        "charge": "Arson",
+        "definition": "A person who willfully and maliciously sets fire to or burns or causes to be burned or who aids or advises the burning of, any structure, forest land, or property.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": false,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 5,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"302": {
-		"id": "302",
-		"charge": "Burglary",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "302": {
+        "id": "302",
+        "charge": "Burglary",
+        "definition": "Any person who enters or unlawfully remains in any unoccupied publicly or privately owned commercial or residential structure, with the intent to procure items through illicit means, or with intent to commit a crime there.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 400000
         },
-		"extra": "N/A"
-	},
-	"303": {
-		"id": "303",
-		"charge": "Home Invasion",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "303": {
+        "id": "303",
+        "charge": "Home Invasion",
+        "definition": "Any person who invades any occupied residential structure with or without knowing if there are people or not in the property when the act took place, with the intent to procure items through illicit means, or with intent to commit a crime therein.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 450000
         },
-		"extra": "N/A"
-	},
-	"304": {
-		"id": "304",
-		"charge": "Grand Theft",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 4,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "304": {
+        "id": "304",
+        "charge": "Grand Theft",
+        "definition": "Any person who steals, takes, carries, leads, or drives away the personal property of another individual or organization in value of $5,501 or more. This charge also includes petty theft of services, which is the intentional failure to pay for rendered services valued at $5,501 or more.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 4,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "N/A"
-	},
-	"305": {
-		"id": "305",
-		"charge": "Petty Theft",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 2,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "305": {
+        "id": "305",
+        "charge": "Petty Theft",
+        "definition": "Any person who steals, takes, carries, leads, or drives away the personal property of another individual or organization in value of $5,500 or less. This charge also includes petty theft of services, which is the intentional failure to pay for rendered services valued at $5,500 or less.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 2,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 25000
         },
-		"extra": "N/A"
-	},
-	"306": {
-		"id": "306",
-		"charge": "Grand Theft Auto",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "306": {
+        "id": "306",
+        "charge": "Grand Theft Auto",
+        "definition": "Any person who steals or attempts to steal or who takes, leads, or drives away another person’s vehicle, without their permission. This charge also includes breaking into a parked vehicle, with or without the attempt to steal the vehicle itself.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 300000
         },
-		"extra": "N/A"
-	},
-	"307": {
-		"id": "307",
-		"charge": "Grand Theft Of A Firearm",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "307": {
+        "id": "307",
+        "charge": "Grand Theft Of A Firearm",
+        "definition": "Any person(s) who commits theft of any registered firearm, no matter the value.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 400000
         },
-		"extra": "N/A"
-	},
-	"308": {
-		"id": "308",
-		"charge": "Possession of Burglary Tools",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "308": {
+        "id": "308",
+        "charge": "Possession of Burglary Tools",
+        "definition": "Any person having upon him or her in his or her possession a picklock, crow, key bit, crowbar, screwdriver, tension bar, lock pick gun, master key, or other instrument or tool with intent to breach a lock without possession of proper licensing.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"309": {
-		"id": "309",
-		"charge": "Receiving Stolen Property",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "309": {
+        "id": "309",
+        "charge": "Receiving Stolen Property",
+        "definition": "Any person who buys or receives any property that has been stolen or that has been obtained in any manner that constitutes theft or extortion with knowledge of status.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"310": {
-		"id": "310",
-		"charge": "Trespassing",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "310": {
+        "id": "310",
+        "charge": "Trespassing",
+        "definition": "Any person who enters another's property with the intent to interfere with or obstruct the business activities conducted thereon, or enters and occupies another's property without permission, or refuses to leave private property after being asked by an owner, manager, resident, or employee.\n\nEvery person who, without the permission of the warden or other officer in charge of any State prison, remains inside a designated prison restricted zone as laid out by the Department of Corrections and Rehabilitation Authorization Act of 2023, after having been given instruction to leave by officers of the law, for the purpose of protecting the prison and keeping the prisoners inside.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"311": {
-		"id": "311",
-		"charge": "Vandalism",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "311": {
+        "id": "311",
+        "charge": "Vandalism",
+        "definition": "Any person who defaces, damages, or destroys property not his or her own. Does not extend to burning. Does not extend to any institution property mentioned in clause 314 of this Title.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"312M": {
-		"id": "312M",
-		"charge": "Embezzlement",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "312M": {
+        "id": "312M",
+        "charge": "Embezzlement",
+        "definition": "Any person who when there was a trust or fiduciary relationship between him or her and a private organization or State or local government agency:\n\na) He or she unlawfully takes such property into their possession or care by virtue of employment.\n\nb) He or she unlawfully engages in a systematic course of conduct constituting a fraudulent conversion or appropriation of property to his/her own use.\n\nc) He or she acts with the intent to deprive the owner of the use of this property.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 3500000
         },
-		"extra": "N/A"
-	},
-	"312F": {
-		"id": "312F",
-		"charge": "Felony Embezzlement",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "312F": {
+        "id": "312F",
+        "charge": "Felony Embezzlement",
+        "definition": "Any person who when there was a trust or fiduciary relationship between him or her and a private organization or State or local government agency:\n\na) He or she unlawfully takes such property into their possession or care by virtue of employment.\n\nb) He or she unlawfully engages in a systematic course of conduct constituting a fraudulent conversion or appropriation of property to his/her own use.\n\nc) He or she acts with the intent to deprive the owner of the use of this property.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 35000
         },
-		"extra": "N/A"
-	},
-	"313M": {
-		"id": "313M",
-		"charge": "Vehicle Registration Theft",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "313M": {
+        "id": "313M",
+        "charge": "Vehicle Registration Theft",
+        "definition": "a) Any person who steals or attempts to steal, or who takes another person's vehicle identification plate.\n\nb) Any person operating a motor vehicle at any time when the vehicle displays another person's vehicle identification plate.\n\nc) Any person who willfully flees or otherwise attempts to elude a pursuing peace officer following a violation of provision (b) of this offense.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"313F": {
-		"id": "313F",
-		"charge": "Vehicle Registration Theft",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "313F": {
+        "id": "313F",
+        "charge": "Vehicle Registration Theft",
+        "definition": "a) Any person who steals or attempts to steal, or who takes another person's vehicle identification plate.\n\nb) Any person operating a motor vehicle at any time when the vehicle displays another person's vehicle identification plate.\n\nc) Any person who willfully flees or otherwise attempts to elude a pursuing peace officer following a violation of provision (b) of this offense.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"314M": {
-		"id": "314M",
-		"charge": "Vandalism of Prison Property (Misdemeanor)",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "314M": {
+        "id": "314M",
+        "charge": "Vandalism of Prison Property (Misdemeanor)",
+        "definition": "Any person who defaces, damages, or destroys any state prison or other institution under the jurisdiction of the Department of Corrections, or any county jail, or any city jail, or any other institution or place where prisoners or inmates are being held under the custody of any law enforcement officers or peace officers or probation officers, or any property belonging to these institutions.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"314F": {
-		"id": "314F",
-		"charge": "Vandalism of Prison Property (Felony)",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "314F": {
+        "id": "314F",
+        "charge": "Vandalism of Prison Property (Felony)",
+        "definition": "Any person who defaces, damages, or destroys any state prison or other institution under the jurisdiction of the Department of Corrections, or any county jail, or any city jail, or any other institution or place where prisoners or inmates are being held under the custody of any law enforcement officers or peace officers or probation officers, or any property belonging to these institutions.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"401": {
-		"id": "401",
-		"charge": "Driving Without a Valid License",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 30
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 1,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "401": {
+        "id": "401",
+        "charge": "Driving Without a Valid License",
+        "definition": "Any person(s) operating a motor vehicle under an expired licensed, or operating a motor vehicle without a license in any capacity. Extends to persons under the age of 16 operating any motor vehicle.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 30
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 1,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 60000
         },
-		"extra": "N/A"
-	},
-	"402": {
-		"id": "402",
-		"charge": "Driving On A Suspended License",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 45
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 2,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "402": {
+        "id": "402",
+        "charge": "Driving On A Suspended License",
+        "definition": "Any person(s) operating a motor vehicle at any time when that person's driving privilege is suspended or revoked.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 45
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 2,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"403": {
-		"id": "403",
-		"charge": "Failure to Produce Driver's License",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "403": {
+        "id": "403",
+        "charge": "Failure to Produce Driver's License",
+        "definition": "Any person who fails to produce a valid driver’s license upon lawful request by a peace officer while operating a motor vehicle on a public roadway.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"404": {
-		"id": "404",
-		"charge": "Failure to Produce Vehicle Registration",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "404": {
+        "id": "404",
+        "charge": "Failure to Produce Vehicle Registration",
+        "definition": "Any person who fails to provide valid proof of vehicle registration upon lawful request by a peace officer while operating or in control of a motor vehicle on a public roadway.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"405": {
-		"id": "405",
-		"charge": "Failure to Produce Proof of Insurance",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "405": {
+        "id": "405",
+        "charge": "Failure to Produce Proof of Insurance",
+        "definition": "Any person who fails to provide valid proof of motor vehicle insurance upon lawful request by a peace officer while operating or in control of a motor vehicle on a public roadway.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"406": {
-		"id": "406",
-		"charge": "Unregistered Vehicle",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 1,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 3,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "406": {
+        "id": "406",
+        "charge": "Unregistered Vehicle",
+        "definition": "Any person who\n(a) drives or operate any motor vehicle or trailer upon a roadway that is unregistered or does not display a valid identification plate; or\n\n(b) leaves standing upon a roadway any motor vehicle or trailer that is unregistered or does not display a valid identification plate.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 1,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 3,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "For driving or operating. If vehicle left standing: fine and impound only."
-	},
-	"407": {
-		"id": "407",
-		"charge": "No Insurance",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 1,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 3,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For driving or operating. If vehicle left standing: fine and impound only."
+    },
+    "407": {
+        "id": "407",
+        "charge": "No Insurance",
+        "definition": "A person commits the offense if they:\n(a) drive or operate any motor vehicle or trailer upon a roadway that is uninsured; or\n\n(b) leave standing upon a roadway any motor vehicle or trailer that is uninsured.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 1,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 3,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "For driving or operating. If vehicle left standing: fine and impound only."
-	},
-	"408": {
-		"id": "408",
-		"charge": "Hit and Run",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For driving or operating. If vehicle left standing: fine and impound only."
+    },
+    "408": {
+        "id": "408",
+        "charge": "Hit and Run",
+        "definition": "a) Any person who whilst operating a motor vehicle is involved in an accident resulting only in damage to property or other vehicles, and fails to immediately stop the vehicle at the scene and remain until the necessary information is exchanged or a law enforcement investigation is concluded. (M)\n\nb) Any person who while operating a motor vehicle is involved in an accident resulting in injury or death to a person and fails to immediately stop the vehicle at the scene and remain until the necessary information is exchanged or a law enforcement investigation is concluded. (F)",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "Misdemeanor version for property damage only. Use 408F for injuries/deaths."
-	},
-	"408F": {
-		"id": "408F",
-		"charge": "Hit and Run (Felony)",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 12,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 3,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Misdemeanor version for property damage only. Use 408F for injuries/deaths."
+    },
+    "408F": {
+        "id": "408F",
+        "charge": "Hit and Run (Felony)",
+        "definition": "a) Any person who whilst operating a motor vehicle is involved in an accident resulting only in damage to property or other vehicles, and fails to immediately stop the vehicle at the scene and remain until the necessary information is exchanged or a law enforcement investigation is concluded. (M)\n\nb) Any person who while operating a motor vehicle is involved in an accident resulting in injury or death to a person and fails to immediately stop the vehicle at the scene and remain until the necessary information is exchanged or a law enforcement investigation is concluded. (F)",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 12,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 3,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 400000
         },
-		"extra": "Felony version for accidents involving injury or death."
-	},
-	"409": {
-		"id": "409",
-		"charge": "Reckless Operation Of an Off-Road or Naval Vehicle",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 15000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 7
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
+        "extra": "Felony version for accidents involving injury or death."
+    },
+    "409": {
+        "id": "409",
+        "charge": "Reckless Operation Of an Off-Road or Naval Vehicle",
+        "definition": "Any person engaging in reckless or careless usage of a non-aerial or street-legal vehicle with or without intent but the creation of distress or the opportunity to cause harm. This can include ATVs, golf carts, boats & naval vehicles, or other equipment not driven on roads.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 15000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 7
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
         "bail": {
             "auto": true,
             "cost": 80000
         },
-		"extra": "Sentencing Enhancements are allowed for this charge."
-	},
-	"410": {
-		"id": "410",
-		"charge": "Speeding",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 8000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "For speeds 1-29 MPH over limit"
-	},
-	"411": {
-		"id": "411",
-		"charge": "Excessive Speeding",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true,
-			"4": true,
-			"5": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 8000,
-			"2": 8000,
-			"3": 12000,
-			"4": 15000,
-			"5": 20000
-		},
-		"impound": {
-			"1": 0,
-			"2": 1,
-			"3": 3,
-			"4": 7,
-			"5": 10
-		},
-		"suspension": {
-			"1": 0,
-			"2": 2,
-			"3": 4,
-			"4": 7,
-			"5": 10
-		},
-		"extra": "For speeds 30+ MPH over limit. Separate offense from Speeding."
-	},
-	"412": {
-		"id": "412",
-		"charge": "Failure to Yield/Stop to a Traffic Control Device",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"413": {
-		"id": "413",
-		"charge": "Failure to Yield at Intersection",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"414": {
-		"id": "414",
-		"charge": "Failure to Yield Entering Roadway",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"415": {
-		"id": "415",
-		"charge": "Failure to Yield for Crosswalk",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"416": {
-		"id": "416",
-		"charge": "Failure to Yield to an Emergency Vehicle",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"417": {
-		"id": "417",
-		"charge": "Improper Lane Entry while Turning",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"418": {
-		"id": "418",
-		"charge": "Prohibited Parking",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 2500,
-			"3": 5000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "Vehicles obstructing traffic or imposing risk may be impounded for 1 Day."
-	},
-	"419": {
-		"id": "419",
-		"charge": "Reckless Driving",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 3,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 3,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Sentencing Enhancements are allowed for this charge."
+    },
+    "410": {
+        "id": "410",
+        "charge": "Speeding",
+        "definition": "Any person who drives a vehicle whilst exceeding the maximum speed limit by 1–29 MPH, based on the type of area:\n\n(a) 100 MPH on highways;\n(b) 75 MPH on county roads;\n(c) 60 MPH within county residential limits, or city limits (excluding highways);\n(d) 45 MPH within state parks, hunting zones, school or university zones.\n\nViolations recorded by automated speed enforcement systems shall be penalized by a fixed fine and must not contribute to the escalation of penalties associated with repeat speeding infractions issued by a peace officer.\n\n\"City limits\" shall be defined as the legal boundary encompassing the city of Los Santos, including all public roadways and streets within that boundary designated for vehicle traffic, excluding highways.\n\"County residential limits\" shall be defined as the legal boundaries encompassing rural townships, including all roadways designated for vehicle traffic within those boundaries, excluding highways and county roads.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 8000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "For speeds 1-29 MPH over limit"
+    },
+    "411": {
+        "id": "411",
+        "charge": "Excessive Speeding",
+        "definition": "Any person who drives a vehicle whilst exceeding the maximum speed limit by 30 MPH or more, based on the type of area outlined in 405. Speeding.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true,
+            "4": true,
+            "5": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 8000,
+            "2": 8000,
+            "3": 12000,
+            "4": 15000,
+            "5": 20000
+        },
+        "impound": {
+            "1": 0,
+            "2": 1,
+            "3": 3,
+            "4": 7,
+            "5": 10
+        },
+        "suspension": {
+            "1": 0,
+            "2": 2,
+            "3": 4,
+            "4": 7,
+            "5": 10
+        },
+        "extra": "For speeds 30+ MPH over limit. Separate offense from Speeding."
+    },
+    "412": {
+        "id": "412",
+        "charge": "Failure to Yield/Stop to a Traffic Control Device",
+        "definition": "Any person who does not comply with traffic control devices or instructions from authorized personnel, including but not limited to:\n(a) stop signs, yield signs, and other regulatory signage;\n(b) cones, barriers, flashing lights, or other temporary traffic control measures indicating roadwork, lane closures, or hazards; or\n(c) instructions from law enforcement officers, construction flaggers, or other authorized personnel directing traffic.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "413": {
+        "id": "413",
+        "charge": "Failure to Yield at Intersection",
+        "definition": "Any person who does not yield the right of way when approaching an intersection in the following situations:\n(a) to any vehicle that has already entered the intersection or is lawfully proceeding through it; or\n(b) to any vehicle approaching from another direction that poses an immediate hazard.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "414": {
+        "id": "414",
+        "charge": "Failure to Yield Entering Roadway",
+        "definition": "Any person who does not yield the right of way when entering a roadway from a private road, driveway, or other non-roadway area to all approaching vehicles on the roadway.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "415": {
+        "id": "415",
+        "charge": "Failure to Yield for Crosswalk",
+        "definition": "Any person who does not yield the right of way to pedestrians who are within or entering a crosswalk. The driver must stop or slow down, as necessary, to ensure pedestrians can cross safely.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "416": {
+        "id": "416",
+        "charge": "Failure to Yield to an Emergency Vehicle",
+        "definition": "Any person who does not yield the right of way in the following situations:\n(a) when an emergency vehicle with flashing lights approaches, the driver must stop in a position parallel to the curb or edge of the road, clear of the intersection, and remain stopped until the emergency vehicle passes; or\n(b) when an emergency vehicle with flashing lights is stopped on a roadway, approaching drivers must move over to the furthest possible lane or edge of the roadway, where applicable, while maintaining safety and legal roadway boundaries, reduce speed, and proceed cautiously.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "417": {
+        "id": "417",
+        "charge": "Improper Lane Entry while Turning",
+        "definition": "Any person who fails to enter the lane closest to their direction of travel when executing a left or right turn at an intersection or roadway junction in a manner that ensures the safe and orderly flow of traffic.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "418": {
+        "id": "418",
+        "charge": "Prohibited Parking",
+        "definition": "Any person who parks a vehicle in violation of the Parking Definitions Act of 2021, including but not limited to:\n(a) blocking lanes, driveways, alleyways, parking lots, or railroad tracks.\n(b) in a crosswalk, sidewalk, median, tunnel, bridge, or against traffic.\n(c) against a red curb (except where permitted).\n(d) on a freeway shoulder (except in emergencies).\n(e) within 5 feet of a fire hydrant.\n(f) at a helipad or aircraft zone (in a non-aerial vehicle).\n(g) in a way that takes up multiple parking spaces.\n(h) more than two motorcycles in a single parking space (unless designated).\n(i) in a handicap space without a permit.\n(j) a non-electric vehicle in an EV charging space.\n\nPrivate property owners may regulate parking and remove unauthorized vehicles.\n\nState & municipal agencies control adjacent parking bays and may restrict access for official use.\nNon-business parking bays remain open to public use",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 2500,
+            "3": 5000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "Vehicles obstructing traffic or imposing risk may be impounded for 1 Day."
+    },
+    "419": {
+        "id": "419",
+        "charge": "Reckless Driving",
+        "definition": "Any person who operates a vehicle in a manner that demonstrates a willful or reckless disregard for the safety of persons or property, creating a foreseeable risk of property damage or minor bodily injury, but not resulting in serious bodily harm or death.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 3,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 3,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"420": {
-		"id": "420",
-		"charge": "Vehicular Endangerment",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 3,
-			"C": 2
-		},
-		"fine": {
-			"1": 10000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "420": {
+        "id": "420",
+        "charge": "Vehicular Endangerment",
+        "definition": "Any person who operates a vehicle in a manner that demonstrates a willful or reckless disregard for the safety of persons or property and, as a result, cause serious bodily harm or death to another person.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 3,
+            "C": 2
+        },
+        "fine": {
+            "1": 10000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"421": {
-		"id": "421",
-		"charge": "Drive Without Headlights",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "Between 20:30-06:30 or reduced visibility conditions"
-	},
-	"422": {
-		"id": "422",
-		"charge": "Unsafe Reversing",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"423": {
-		"id": "423",
-		"charge": "Obstructing Traffic",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"424": {
-		"id": "424",
-		"charge": "Driving Against One-way Traffic",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"425": {
-		"id": "425",
-		"charge": "Imprudent Driving",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"426": {
-		"id": "426",
-		"charge": "Use of an Electronic Device while Driving",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "Excludes hands-free devices"
-	},
-	"427": {
-		"id": "427",
-		"charge": "Vehicular Noise Violation",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"428": {
-		"id": "428",
-		"charge": "Illegal Usage of Hydraulics",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 2
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"429": {
-		"id": "429",
-		"charge": "Tinted Windows",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 2500,
-			"3": 5000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "Tints of Level 1 and 2 are considered illegal unless exempted"
-	},
-	"430": {
-		"id": "430",
-		"charge": "Impaired Driving [DUI]",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 8000,
-			"3": 12000
-		},
-		"impound": {
-			"1": 3,
-			"2": 7,
-			"3": 10
-		},
-		"suspension": {
-			"1": 3,
-			"2": 7,
-			"3": 10
-		},
+        "extra": "N/A"
+    },
+    "421": {
+        "id": "421",
+        "charge": "Drive Without Headlights",
+        "definition": "Any person who drives a vehicle on a roadway without illuminating their vehicle’s lamps between 20:30 (8:30 PM) and 06:30 (6:30 AM) or at any time when visibility is reduced due to weather, road conditions, or other factors.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "Between 20:30-06:30 or reduced visibility conditions"
+    },
+    "422": {
+        "id": "422",
+        "charge": "Unsafe Reversing",
+        "definition": "Any person who operates a motor vehicle in reverse in a manner that creates a hazard to other road users, including but not limited to:\n(a) reversing into moving traffic;\n(b) reversing without maintaining proper visibility or control; or\n(c) failing to yield to vehicles or pedestrians when reversing.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "423": {
+        "id": "423",
+        "charge": "Obstructing Traffic",
+        "definition": "Any person who stops a vehicle on a roadway in a manner that obstructs the normal flow of traffic, unless required by law or directed by a peace officer.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "424": {
+        "id": "424",
+        "charge": "Driving Against One-way Traffic",
+        "definition": "Any person who operates a motor vehicle in the opposite direction of designated one-way traffic on a roadway, except when directed to do so by a law enforcement officer or authorized traffic control personnel.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "425": {
+        "id": "425",
+        "charge": "Imprudent Driving",
+        "definition": "Any person who operates a vehicle on a roadway without reasonable care or consideration for factors that affect safe operation, including but not limited to:\n(a) failing to adjust driving behavior according to road conditions, weather, visibility, or surrounding traffic; or\n(b) engaging in activities that impair their ability to maintain full control of the vehicle, including but not limited to eating, reaching for objects, interacting with passengers in a manner that distracts from driving, or personal grooming.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "426": {
+        "id": "426",
+        "charge": "Use of an Electronic Device while Driving",
+        "definition": "Any person who manually operates, hold, or otherwise physically interact with an electronic device while driving or operating a motor vehicle on a roadway, except in cases of emergency or when using a hands-free mode that does not require physical handling of the device.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "Excludes hands-free devices"
+    },
+    "427": {
+        "id": "427",
+        "charge": "Vehicular Noise Violation",
+        "definition": "Any person who operates a vehicle in a manner that emits excessive noise, including but not limited to:\n\n(a) unnecessary use of the vehicle's horn;\n(b) playing loud music or audio at volumes that disregard noise pollution or disturb public peace;\n(c)  excessive revving of the engine; or\n(d) operating a vehicle with a modified or faulty exhaust system that generates unreasonable noise levels",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "428": {
+        "id": "428",
+        "charge": "Illegal Usage of Hydraulics",
+        "definition": "Any person operating a vehicle that has hydraulic equipment installed on the chassis or other component(s) of the vehicle without legitimate equipment need or purpose (such as a forklift) may not use such hydraulics while on a state, county, or local road.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 2
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "429": {
+        "id": "429",
+        "charge": "Tinted Windows",
+        "definition": "Any person operating a vehicle and unlawfully uses tints, or anonymizing shades on his or her windows leading to an individual driving with tinted windows unable to be identified while driving, unless listed exempt under standing laws.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 2500,
+            "3": 5000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "Tints of Level 1 and 2 are considered illegal unless exempted"
+    },
+    "430": {
+        "id": "430",
+        "charge": "Impaired Driving [DUI]",
+        "definition": "Any person who drives any vehicle upon any highway, roadway, or public vehicular area within this state:\n(a) while under the influence of an impairing substance;\n(b) after having consumed sufficient alcohol that they have, at any relevant time after driving, an alcohol concentration of 0.08 or more; or\n(c) with any amount of a Schedule I controlled substance, as listed in the Drug Enforcement & Prevention Act of 2020 (DEPA), in their system or its metabolites in their blood or urine.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 8000,
+            "3": 12000
+        },
+        "impound": {
+            "1": 3,
+            "2": 7,
+            "3": 10
+        },
+        "suspension": {
+            "1": 3,
+            "2": 7,
+            "3": 10
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "Third offense upgraded to Felony [2]"
-	},
-	"431": {
-		"id": "431",
-		"charge": "Refusal to Submit to Testing",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5000,
-			"2": 8000,
-			"3": 12000
-		},
-		"impound": {
-			"1": 3,
-			"2": 7,
-			"3": 10
-		},
-		"suspension": {
-			"1": 3,
-			"2": 7,
-			"3": 10
-		},
+        "extra": "Third offense upgraded to Felony [2]"
+    },
+    "431": {
+        "id": "431",
+        "charge": "Refusal to Submit to Testing",
+        "definition": "Any person who, having been lawfully requested by a peace officer to participate in a standard field sobriety test or to provide a sample of their breath, blood, or other bodily substances for chemical testing, refuses or fails to comply with the request.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5000,
+            "2": 8000,
+            "3": 12000
+        },
+        "impound": {
+            "1": 3,
+            "2": 7,
+            "3": 10
+        },
+        "suspension": {
+            "1": 3,
+            "2": 7,
+            "3": 10
+        },
         "bail": {
             "auto": true,
             "cost": 25000
         },
-		"extra": "Third offense upgraded to Felony [2]"
-	},
-	"432M": {
-		"id": "432M",
-		"charge": "Motor Vehicle Contest (Misdemeanor)",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 5500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 7,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 7,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Third offense upgraded to Felony [2]"
+    },
+    "432M": {
+        "id": "432M",
+        "charge": "Motor Vehicle Contest (Misdemeanor)",
+        "definition": "(a) Any person performing an unlicensed or undesignated race or competition on city, county, or state paved roads or courses that incites the potential for other violations or demonstrates a potential for hazard.\n\n(b) Any person who willfully flees or otherwise attempts to elude a pursuing peace officer following a violation of provision (a) of this offense.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 5500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 7,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 7,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"432F": {
-		"id": "432F",
-		"charge": "Motor Vehicle Contest (Felony)",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"1": 15000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 10,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 7,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "432F": {
+        "id": "432F",
+        "charge": "Motor Vehicle Contest (Felony)",
+        "definition": "(a) Any person performing an unlicensed or undesignated race or competition on city, county, or state paved roads or courses that incites the potential for other violations or demonstrates a potential for hazard.\n\n(b) Any person who willfully flees or otherwise attempts to elude a pursuing peace officer following a violation of provision (a) of this offense.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "1": 15000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 10,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 7,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "Evading charged additionally. For fleeing from officers after street race."
-	},
-	"433": {
-		"id": "433",
-		"charge": "Jaywalking",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"434": {
-		"id": "434",
-		"charge": "Possession of Open Container",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"435": {
-		"id": "435",
-		"charge": "Failure to Wear a Seatbelt/Safety Equipment",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"436": {
-		"id": "436",
-		"charge": "Operation of Unsafe Motor Vehicle",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 2,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"437": {
-		"id": "437",
-		"charge": "Operating an Aircraft Without A License",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "Evading charged additionally. For fleeing from officers after street race."
+    },
+    "433": {
+        "id": "433",
+        "charge": "Jaywalking",
+        "definition": "Any person who intentionally or recklessly crosses a roadway as a pedestrian in a manner that:\n\na) Creates a foreseeable risk of obstructing the flow of traffic; or\n\nb) Otherwise poses a hazard to other road users.\n\nPedestrians must use designated crosswalks where available. Crossing outside of a crosswalk between intersections, or against pedestrian signals, shall constitute jaywalking.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "434": {
+        "id": "434",
+        "charge": "Possession of Open Container",
+        "definition": "Any person who holds possession of open containers of alcoholic beverages or any containers carrying performance-altering substances while operating a vehicle.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "435": {
+        "id": "435",
+        "charge": "Failure to Wear a Seatbelt/Safety Equipment",
+        "definition": "Any person who whilst operating a motor vehicle, does not properly secure themselves in with the safety belt, or adhere to traffic safety standards when operating vehicles such as motorcycles, ATV's, and other Wheeled single-track vehicles without a helmet or other proper safety equipment for proper operation.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "436": {
+        "id": "436",
+        "charge": "Operation of Unsafe Motor Vehicle",
+        "definition": "Any person who drives or moves a motor vehicle, cycle or combination of vehicles on any public road, which is in an unsafe condition as to endanger any person or property, suffers substantial structural damage, or is not equipped with lights, brakes, steering and other equipment in proper condition.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 2,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "437": {
+        "id": "437",
+        "charge": "Operating an Aircraft Without A License",
+        "definition": "Any person(s) who operates any aircraft without the appropriate license.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"438": {
-		"id": "438",
-		"charge": "Reckless Operation Of An Aircraft",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 50000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 3,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "438": {
+        "id": "438",
+        "charge": "Reckless Operation Of An Aircraft",
+        "definition": "Any person(s) who endangers life through the operation of their aircraft, such as flying at low altitude in an urban or suburban area.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 50000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 3,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "N/A"
-	},
-	"439": {
-		"id": "439",
-		"charge": "Failure To Adhere To ATC",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 50000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "439": {
+        "id": "439",
+        "charge": "Failure To Adhere To ATC",
+        "definition": "Any person(s) who, whilst operating an aircraft, fails to adhere to ATC protocol or commands.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 50000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "(( Charge is suspended. DO NOT charge this on any person. ))"
-	},
-	"440": {
-		"id": "440",
-		"charge": "Aerial Evasion",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 100000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 7,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "(( Charge is suspended. DO NOT charge this on any person. ))"
+    },
+    "440": {
+        "id": "440",
+        "charge": "Aerial Evasion",
+        "definition": "Any person(s) who evades any law enforcement agency via an aircraft, whether as a pilot or passenger.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 100000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 7,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"441": {
-		"id": "441",
-		"charge": "Negligent Operation of Bicycle",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"442": {
-		"id": "442",
-		"charge": "Operation of an Unauthorized Vehicle on Vespucci Beach",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 2500,
-			"2": 5000,
-			"3": 7500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 3
-		},
-		"extra": "N/A"
-	},
-	"443": {
-		"id": "443",
-		"charge": "Street Takeover",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"1": 20000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 7,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 7,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "441": {
+        "id": "441",
+        "charge": "Negligent Operation of Bicycle",
+        "definition": "Any person(s) operating a bicycle in a manner that will likely cause property damage or harm to other road users or pedestrians.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "442": {
+        "id": "442",
+        "charge": "Operation of an Unauthorized Vehicle on Vespucci Beach",
+        "definition": "Any person(s) engaging in the unlawful operation or usage of a vehicle directly in violation of the Vespucci Beach Motor Vehicle Regulations Act.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 2500,
+            "2": 5000,
+            "3": 7500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 3
+        },
+        "extra": "N/A"
+    },
+    "443": {
+        "id": "443",
+        "charge": "Street Takeover",
+        "definition": "Any person who organizes, promotes, facilitates, or actively participates in a coordinated effort to obstruct or take control of a highway, roadway, parking lot, or any other area—whether publicly or privately owned—without explicit consent from the property owner, for the purpose of enabling or engaging in:\n(a) unauthorized motor vehicle exhibitions, including but not limited to races, drag races, burnouts, doughnuts, drifting, wheelies, or other stunt driving; or\n(b) any gathering intended to interfere with traffic flow or pose a significant public safety risk through the reckless operation of motor vehicles.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "1": 20000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 7,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 7,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 350000
         },
-		"extra": "14 day impound for evading, plus Evading a Peace Officer charge added separately"
-	},
-	"501": {
-		"id": "501",
-		"charge": "Indecent Exposure",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "14 day impound for evading, plus Evading a Peace Officer charge added separately"
+    },
+    "501": {
+        "id": "501",
+        "charge": "Indecent Exposure",
+        "definition": "Any person(s) who willfully and lewdly exposes their person, or the private parts thereof, in any public place, or in any place where there are present other persons.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 300000
         },
-		"extra": "N/A"
-	},
-	"502": {
-		"id": "502",
-		"charge": "Lewd or Dissolute Conduct in Public",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "502": {
+        "id": "502",
+        "charge": "Lewd or Dissolute Conduct in Public",
+        "definition": "Any person(s) who solicits anyone to engage in or engages in lewd or dissolute or inappropriate conduct in any public place or in any place open to the public or exposed to public view.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "N/A"
-	},
-	"503": {
-		"id": "503",
-		"charge": "Prostitution",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": true,
-			"3": true
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "503": {
+        "id": "503",
+        "charge": "Prostitution",
+        "definition": "Any person(s) who encourages or persuades a person to engage in sexual activity for monetary gain, whether it be the prostitute or the customer.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": true,
+            "3": true
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 150000
         },
-		"extra": "N/A"
-	},
-	"504": {
-		"id": "504",
-		"charge": "Pandering/Pimping",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "504": {
+        "id": "504",
+        "charge": "Pandering/Pimping",
+        "definition": "Any person who solicits or advertises, aids, or provides transport or otherwise supervises persons involved in prostitution and retains money earned during the commission of the offense of prostitution or any person who causes, induces or encourages another person to become a prostitute by promises, threats, violence or any scheme.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 400000
         },
-		"extra": "N/A"
-	},
-	"505": {
-		"id": "505",
-		"charge": "Stalking",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 3,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "505": {
+        "id": "505",
+        "charge": "Stalking",
+        "definition": "Any person who willfully, maliciously, and repeatedly follows or willfully and maliciously harasses another person, and who makes a credible threat with the intent to place that person in reasonable fear for his or her safety, or the safety of his or her immediate family.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 3,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"506M": {
-		"id": "506M",
-		"charge": "Misdemeanor Gaming Fraud",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 12,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "506M": {
+        "id": "506M",
+        "charge": "Misdemeanor Gaming Fraud",
+        "definition": "Any person who by any device, sleight of hand, trick, deception or other means whatever, by use of cards or other implements or instruments, or while betting during any play or game, fraudulently obtains from another person money or property.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 12,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 450000
         },
-		"extra": "N/A"
-	},
-	"506F": {
-		"id": "506F",
-		"charge": "Felony Gaming Fraud",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "506F": {
+        "id": "506F",
+        "charge": "Felony Gaming Fraud",
+        "definition": "Any person who by any device, sleight of hand, trick, deception or other means whatever, by use of cards or other implements or instruments, or while betting during any play or game, fraudulently obtains from another person money or property.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 450000
         },
-		"extra": "N/A"
-	},
-	"507": {
-		"id": "507",
-		"charge": "Child Abuse",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 3,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "507": {
+        "id": "507",
+        "charge": "Child Abuse",
+        "definition": "Any person who willfully inflicts upon a child under 18 years old any cruel or inhumane corporal punishment or an injury resulting in a traumatic condition, or puts a child in a situation or circumstance that invites great bodily harm or injury, or causes minor harm or injury to the child.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 3,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"508": {
-		"id": "508",
-		"charge": "Child Neglect",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 3,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "508": {
+        "id": "508",
+        "charge": "Child Neglect",
+        "definition": "Any person who fails to provide physical necessities such as clothing, food, shelter, and medical or other remedial care for his/her minor child without a lawful excuse.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 3,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "N/A"
-	},
-	"509": {
-		"id": "509",
-		"charge": "Sale of Alcohol / Tobacco to a Minor",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 2,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "509": {
+        "id": "509",
+        "charge": "Sale of Alcohol / Tobacco to a Minor",
+        "definition": "Any person(s) who sell, give, serve, or permit to be served alcoholic beverages or tobacco to a person under 21 years of age, or permit a person under 21 years of age to consume such beverages or tobacco on the licensed premises.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 2,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 80000
         },
-		"extra": "N/A"
-	},
-	"510": {
-		"id": "510",
-		"charge": "Minor Alcohol / Tobacco Violation",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "510": {
+        "id": "510",
+        "charge": "Minor Alcohol / Tobacco Violation",
+        "definition": "Any person under the age of 21 who is in possession of alcohol, alcohol-based products, or appears to be under the influence of alcohol, or any tobacco-based products.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"511": {
-		"id": "511",
-		"charge": "Animal Abuse",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 5,
-			"B": 4,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "511": {
+        "id": "511",
+        "charge": "Animal Abuse",
+        "definition": "Any person who maliciously and intentionally maims, mutilates, tortures, assaults, wounds, or kills a living animal, or holds ownership to a pet that is not considered domesticated and safe for the animal or the owner.",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 5,
+            "B": 4,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 50000
         },
-		"extra": "N/A"
-	},
-	"512": {
-		"id": "512",
-		"charge": "Sexual Activity With An Inmate",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "512": {
+        "id": "512",
+        "charge": "Sexual Activity With An Inmate",
+        "definition": "Any officer or employee of the Department of Health and Human Services, or of a health facility confining persons who are guilty of a public offense, or of any detention facility as defined in (b), in the premises of any detention facility, who engages in sexual activity with a consenting adult who is confined to that detention facility or health facility, shall be guilty of a felony.\n\n(b) This clause follows the definitions of any detention facility as defined in the Department of Corrections and Rehabilitations Act of 2023",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"601": {
-		"id": "601",
-		"charge": "Manufacturing A Controlled Substance",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 14,
-				"hours": 0,
-				"min": 0
-			},
-			"B": {
-				"days": 12,
-				"hours": 0,
-				"min": 0
-			},
-			"C": {
-				"days": 10,
-				"hours": 0,
-				"min": 0
-			},
-			"D": {
-				"days": 8,
-				"hours": 0,
-				"min": 0
-			},
-			"T": {
-				"days": 3,
-				"hours": 0,
-				"min": 0
-			}
-		},
+        "extra": "N/A"
+    },
+    "601": {
+        "id": "601",
+        "charge": "Manufacturing A Controlled Substance",
+        "definition": "Any person who manufactures, compounds, converts, produces, derives, processes, or prepares, either directly or indirectly by chemical or natural extraction any illegal or prescription substance without proper permits. The highest category being manufactured determines the overall penalty.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 14,
+                "hours": 0,
+                "min": 0
+            },
+            "B": {
+                "days": 12,
+                "hours": 0,
+                "min": 0
+            },
+            "C": {
+                "days": 10,
+                "hours": 0,
+                "min": 0
+            },
+            "D": {
+                "days": 8,
+                "hours": 0,
+                "min": 0
+            },
+            "T": {
+                "days": 3,
+                "hours": 0,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 7
+        },
+        "fine": {
+            "A": 50000,
+            "B": 45000,
+            "C": 40000,
+            "D": 20000,
+            "T": 15000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": true,
@@ -7306,78 +7420,79 @@
                 "T": 470000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 7
-		},
-		"fine": {
-			"A": 50000,
-			"B": 45000,
-			"C": 40000,
-			"D": 20000,
-			"T": 15000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T"
-		}
-	},
-	"602": {
-		"id": "602",
-		"charge": "Possession Of A Controlled Substance",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 0,
-				"hours": 20,
-				"min": 0
-			},
-			"B": {
-				"days": 0,
-				"hours": 15,
-				"min": 0
-			},
-			"C": {
-				"days": 0,
-				"hours": 10,
-				"min": 0
-			},
-			"D": {
-				"days": 0,
-				"hours": 0,
-				"min": 0
-			},
-			"T": {
-				"days": 0,
-				"hours": 0,
-				"min": 0
-			}
-		},
+        "extra": "N/A",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T"
+        }
+    },
+    "602": {
+        "id": "602",
+        "charge": "Possession Of A Controlled Substance",
+        "definition": "Any person who possesses any controlled substance or multiple controlled substances except when dispensed or prescribed by or under the direction of a person licensed by the state to dispense, prescribe, or administer controlled substances. This shall apply to any measurements of less than 15 grams. The highest category in possession determines overall penalty.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 0,
+                "hours": 20,
+                "min": 0
+            },
+            "B": {
+                "days": 0,
+                "hours": 15,
+                "min": 0
+            },
+            "C": {
+                "days": 0,
+                "hours": 10,
+                "min": 0
+            },
+            "D": {
+                "days": 0,
+                "hours": 0,
+                "min": 0
+            },
+            "T": {
+                "days": 0,
+                "hours": 0,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "A": 4500,
+            "B": 3750,
+            "C": 3000,
+            "D": 2250,
+            "T": 500
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": true,
@@ -7394,78 +7509,79 @@
                 "T": 20000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"A": 4500,
-			"B": 3750,
-			"C": 3000,
-			"D": 2250,
-			"T": 500
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T"
-		}
-	},
-	"603": {
-		"id": "603",
-		"charge": "Possession Of A Controlled Substance with Intent to Distribute",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 2,
-				"hours": 0,
-				"min": 0
-			},
-			"B": {
-				"days": 1,
-				"hours": 0,
-				"min": 0
-			},
-			"C": {
-				"days": 0,
-				"hours": 14,
-				"min": 0
-			},
-			"D": {
-				"days": 0,
-				"hours": 12,
-				"min": 0
-			},
-			"T": {
-				"days": 0,
-				"hours": 6,
-				"min": 0
-			}
-		},
+        "extra": "N/A",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T"
+        }
+    },
+    "603": {
+        "id": "603",
+        "charge": "Possession Of A Controlled Substance with Intent to Distribute",
+        "definition": "Any person who possesses any controlled substance or multiple controlled substances with the intent to distribute, deliver, or sell. This shall also automatically apply to any measurements 15 grams and above, regardless of individual intent. The highest category in possession determines the overall penalty.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 2,
+                "hours": 0,
+                "min": 0
+            },
+            "B": {
+                "days": 1,
+                "hours": 0,
+                "min": 0
+            },
+            "C": {
+                "days": 0,
+                "hours": 14,
+                "min": 0
+            },
+            "D": {
+                "days": 0,
+                "hours": 12,
+                "min": 0
+            },
+            "T": {
+                "days": 0,
+                "hours": 6,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "A": 15000,
+            "B": 10500,
+            "C": 7000,
+            "D": 5250,
+            "T": 1000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": true,
@@ -7482,78 +7598,79 @@
                 "T": 30000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"A": 15000,
-			"B": 10500,
-			"C": 7000,
-			"D": 5250,
-			"T": 1000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T"
-		}
-	},
-	"604": {
-		"id": "604",
-		"charge": "Criminal Sale Of a Controlled Substance",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 2,
-				"hours": 0,
-				"min": 0
-			},
-			"B": {
-				"days": 1,
-				"hours": 0,
-				"min": 0
-			},
-			"C": {
-				"days": 0,
-				"hours": 14,
-				"min": 0
-			},
-			"D": {
-				"days": 0,
-				"hours": 12,
-				"min": 0
-			},
-			"T": {
-				"days": 0,
-				"hours": 6,
-				"min": 0
-			}
-		},
+        "extra": "N/A",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T"
+        }
+    },
+    "604": {
+        "id": "604",
+        "charge": "Criminal Sale Of a Controlled Substance",
+        "definition": "Any person who knowingly and unlawfully sells one or more preparations, compounds, or  mixtures containing controlled substances.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 2,
+                "hours": 0,
+                "min": 0
+            },
+            "B": {
+                "days": 1,
+                "hours": 0,
+                "min": 0
+            },
+            "C": {
+                "days": 0,
+                "hours": 14,
+                "min": 0
+            },
+            "D": {
+                "days": 0,
+                "hours": 12,
+                "min": 0
+            },
+            "T": {
+                "days": 0,
+                "hours": 6,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "A": 15000,
+            "B": 10500,
+            "C": 7000,
+            "D": 5250,
+            "T": 1000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": true,
@@ -7570,78 +7687,79 @@
                 "T": 70000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"A": 15000,
-			"B": 10500,
-			"C": 7000,
-			"D": 5250,
-			"T": 1000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T"
-		}
-	},
-	"605": {
-		"id": "605",
-		"charge": "Drug Smuggling",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 4,
-				"hours": 0,
-				"min": 0
-			},
-			"B": {
-				"days": 3,
-				"hours": 0,
-				"min": 0
-			},
-			"C": {
-				"days": 2,
-				"hours": 0,
-				"min": 0
-			},
-			"D": {
-				"days": 1,
-				"hours": 0,
-				"min": 0
-			},
-			"T": {
-				"days": 0,
-				"hours": 10,
-				"min": 0
-			}
-		},
+        "extra": "N/A",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T"
+        }
+    },
+    "605": {
+        "id": "605",
+        "charge": "Drug Smuggling",
+        "definition": "Any person who attempts, or is successful in the act of transporting, exporting, storing or concealing controlled substances or multiple controlled substances on their person or in their property in excess of measurements of 35 grams or above, regardless of individual intent.  This shall also apply for transportation across jurisdictions. The highest category in possession determines the overall penalty.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 4,
+                "hours": 0,
+                "min": 0
+            },
+            "B": {
+                "days": 3,
+                "hours": 0,
+                "min": 0
+            },
+            "C": {
+                "days": 2,
+                "hours": 0,
+                "min": 0
+            },
+            "D": {
+                "days": 1,
+                "hours": 0,
+                "min": 0
+            },
+            "T": {
+                "days": 0,
+                "hours": 10,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 3
+        },
+        "fine": {
+            "A": 22500,
+            "B": 18750,
+            "C": 15000,
+            "D": 11500,
+            "T": 4000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": true,
@@ -7658,78 +7776,79 @@
                 "T": 80000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 3
-		},
-		"fine": {
-			"A": 22500,
-			"B": 18750,
-			"C": 15000,
-			"D": 11500,
-			"T": 4000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T"
-		}
-	},
-	"606": {
-		"id": "606",
-		"charge": "Drug Trafficking",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"A": {
-				"days": 7,
-				"hours": 0,
-				"min": 0
-			},
-			"B": {
-				"days": 6,
-				"hours": 0,
-				"min": 0
-			},
-			"C": {
-				"days": 5,
-				"hours": 0,
-				"min": 0
-			},
-			"D": {
-				"days": 4,
-				"hours": 0,
-				"min": 0
-			},
-			"T": {
-				"days": 1,
-				"hours": 0,
-				"min": 0
-			}
-		},
+        "extra": "N/A",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T"
+        }
+    },
+    "606": {
+        "id": "606",
+        "charge": "Drug Trafficking",
+        "definition": "Any person(s) who attempts, or is successful in the act of transporting, importing, exporting a controlled substance or multiple controlled substances on their person or in their property in excess of measurements of 75 grams or above, regardless of individual intent.  This shall also apply for transportation across jurisdictions to enable the supply or distribution. The highest category in possession determines the overall penalty.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "A": {
+                "days": 7,
+                "hours": 0,
+                "min": 0
+            },
+            "B": {
+                "days": 6,
+                "hours": 0,
+                "min": 0
+            },
+            "C": {
+                "days": 5,
+                "hours": 0,
+                "min": 0
+            },
+            "D": {
+                "days": 4,
+                "hours": 0,
+                "min": 0
+            },
+            "T": {
+                "days": 1,
+                "hours": 0,
+                "min": 0
+            }
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "A": 45000,
+            "B": 37500,
+            "C": 30000,
+            "D": 22500,
+            "T": 8000
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": {
                 "A": 2,
@@ -7746,958 +7865,954 @@
                 "T": 100000
             }
         },
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"A": 45000,
-			"B": 37500,
-			"C": 30000,
-			"D": 22500,
-			"T": 8000
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "For every additional 75 grams in possession upon detainment or arrest, an additional 12 hours will be added to the sentence.",
-		"drugs": {
-			"1": "A",
-			"2": "B",
-			"3": "C",
-			"4": "D",
-			"5": "T"
-		}
-	},
-	"607": {
-		"id": "607",
-		"charge": "Possession of Drug Paraphernalia",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 4500,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "For every additional 75 grams in possession upon detainment or arrest, an additional 12 hours will be added to the sentence.",
+        "drugs": {
+            "1": "A",
+            "2": "B",
+            "3": "C",
+            "4": "D",
+            "5": "T"
+        }
+    },
+    "607": {
+        "id": "607",
+        "charge": "Possession of Drug Paraphernalia",
+        "definition": "Any person who knowingly possesses any device, instrument or paraphernalia used for or designed for unlawfully injecting or smoking a controlled substance, packaging, measuring or weighing controlled substances such as gelatine capsules, vials, capsules, scales or glassine envelopes.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 4500,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	
-	"609": {
-		"id": "609",
-		"charge": "Eavesdropping",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 4,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "609": {
+        "id": "609",
+        "charge": "Eavesdropping",
+        "definition": "Any person who unlawfully engages in wiretapping, mechanical overhearing of a conversation, or intercepting or accessing of an electronic communication.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 4,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "N/A"
-	},
-	"610": {
-		"id": "610",
-		"charge": "Facial Obstruction",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 1,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "610": {
+        "id": "610",
+        "charge": "Facial Obstruction",
+        "definition": "Any person who obstructs or disguises their face, during the commission of a crime, shall be charged under this statute.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 1,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"611": {
-		"id": "611",
-		"charge": "Fire Code Violation",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 3000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"612": {
-		"id": "612",
-		"charge": "Littering",
-		"type": "I",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 1000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"extra": "N/A"
-	},
-	"613": {
-		"id": "613",
-		"charge": "SRCB Violation",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 10,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 50000,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "611": {
+        "id": "611",
+        "charge": "Fire Code Violation",
+        "definition": "Any violation concerning fire code, enforced by the fire marshal.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 3000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "612": {
+        "id": "612",
+        "charge": "Littering",
+        "definition": "Any person who discards, drops, or scatters waste matter in a place other than a container or proper disposal, in a public or private property, other than his or her own property.",
+        "type": "I",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 1000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "extra": "N/A"
+    },
+    "613": {
+        "id": "613",
+        "charge": "SRCB Violation",
+        "definition": "Any person(s) who fail to abide by the provisions of the State Regulation of Charities Act, shall be deemed guilty of this offence.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 10,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 50000,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"701": {
-		"id": "701",
-		"charge": "Criminal Possession of a Firearm",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "701": {
+        "id": "701",
+        "charge": "Criminal Possession of a Firearm",
+        "definition": "Any person who carries a weapon on their person or in their vehicle, place of business, or another private facility without proper relevant permits or without the knowledge or consent (implied or expressed) of an individual within their vehicle, place of business, or another private facility who possesses such permits is in violation of the law. This shall also extend to firearms without a valid serial number.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 400000
         },
-		"extra": "N/A"
-	},
-	"702": {
-		"id": "702",
-		"charge": "Possession of a Prohibited Firearm",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 6,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "702": {
+        "id": "702",
+        "charge": "Possession of a Prohibited Firearm",
+        "definition": "Any person who possesses any firearm that is prohibited by state or federal law, or contains illegal modifications in its setup, or firearms banned from entry, sale, or transportation into the State of San Andreas, without appropriate permit.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 6,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 400000
         },
-		"extra": "N/A"
-	},
-	"703": {
-		"id": "703",
-		"charge": "Aggravated Firearm Possession",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 10,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "703": {
+        "id": "703",
+        "charge": "Aggravated Firearm Possession",
+        "definition": "Any person who carries on their person, or in their vehicle, place of business or another private facility more than five Unlicensed Firearms or more than three Prohibited Firearms as provided in P.C 701 and P.C 702.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 10,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"704": {
-		"id": "704",
-		"charge": "Possession of an Explosive or Incendiary Device",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "704": {
+        "id": "704",
+        "charge": "Possession of an Explosive or Incendiary Device",
+        "definition": "Any person who possesses any explosive or incendiary device that is prohibited by state or federal law or explosive or incendiary devices banned from entry, sale, or transportation into the State of San Andreas, without appropriate permit.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	},
-	"705": {
-		"id": "705",
-		"charge": "Unlicensed Sale of Firearm or Explosives",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "705": {
+        "id": "705",
+        "charge": "Unlicensed Sale of Firearm or Explosives",
+        "definition": "Any person who illegally sells, gives, or buys firearms, explosives, incendiary devices, or any other similar device or improvised devices of any type without proper permits or permissions.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 800000
         },
-		"extra": "N/A"
-	},
-	"706": {
-		"id": "706",
-		"charge": "Brandishing a Deadly Weapon",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 3,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "706": {
+        "id": "706",
+        "charge": "Brandishing a Deadly Weapon",
+        "definition": "Any person who, except in self-defense, in the presence of another person, draws, holds, points, or exhibits a deadly weapon or instrument, firearm or object similar, whether loaded or unloaded in a rude, angry, or threatening manner as to reasonably induce fear in the mind of another.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 3,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"707": {
-		"id": "707",
-		"charge": "Discharging A Firearm in Public",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 8,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "707": {
+        "id": "707",
+        "charge": "Discharging A Firearm in Public",
+        "definition": "Any person who intentionally discharges a firearm into any building, vehicle, or in a public or other populated area, causing severe endangerment, actual physical harm, or risk of physical harm to another person.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 8,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"708": {
-		"id": "708",
-		"charge": "Discharging A Firearm From A Motor Vehicle",
-		"type": "F",
-		"class": {
-			"A": true,
-			"B": true,
-			"C": false
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 5,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 7,
-			"B": 5,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "708": {
+        "id": "708",
+        "charge": "Discharging A Firearm From A Motor Vehicle",
+        "definition": "a) Any driver or owner of any vehicle who knowingly permits any other person to discharge any firearm from the vehicle.\n\nb) Any person who willfully and maliciously discharges a firearm from a motor vehicle at another person other than an occupant of a motor vehicle",
+        "type": "F",
+        "class": {
+            "A": true,
+            "B": true,
+            "C": false
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 5,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 7,
+            "B": 5,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": false,
             "cost": 0
         },
-		"extra": "N/A"
-	},
-	"709": {
-		"id": "709",
-		"charge": "Reckless Handling of Firearms",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": true,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 6,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "709": {
+        "id": "709",
+        "charge": "Reckless Handling of Firearms",
+        "definition": "a) Any person who handles any firearm in a grossly negligent manner so as to endanger the life, limb or property of any person.\n\nb) Any person who carries or transports a firearm while under the influence of marijuana, narcotic drug, mind altering drug, any other controlled substance, or exceeding 0.08% BAC.\n\nc) Any person whose license to hunt and trap, or whose privilege to hunt and trap while in possession of a firearm, has been revoked, thereafter hunts or traps while in possession of a firearm.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": true,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 6,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 250000
         },
-		"extra": "N/A"
-	},
-	"710": {
-		"id": "710",
-		"charge": "SHAFT Code Violation",
-		"type": "M",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 0,
-			"hours": 3,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 2,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 0
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "710": {
+        "id": "710",
+        "charge": "SHAFT Code Violation",
+        "definition": "Any person who fails to abide by firearm regulations as endorsed by the State Handling and Firearms Training Act given by the municipal authority.",
+        "type": "M",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 0,
+            "hours": 3,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 2,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 0
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 100000
         },
-		"extra": "N/A"
-	},
-	"711": {
-		"id": "711",
-		"charge": "Possession of a Firearm by Convicted Felon",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 5
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "711": {
+        "id": "711",
+        "charge": "Possession of a Firearm by Convicted Felon",
+        "definition": "Any person who carries or possesses a firearm on their person, vehicle, place of business, or another facility they own or are directly managing while being previously convicted of a felony charge under the laws of the United States or San Andreas is guilty of a Felony.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 5
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 800000
         },
-		"extra": "N/A"
-	},
-	"712": {
-		"id": "712",
-		"charge": "Unlawful Possession of Ammunition",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 1,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 4,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 2
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "712": {
+        "id": "712",
+        "charge": "Unlawful Possession of Ammunition",
+        "definition": "Any person who stores or possesses firearm ammunition on their person, vehicle, place of business or another facility they own or are directly managing while being previously convicted of a felony charge under the laws of the United States or San Andreas is guilty of a Felony.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 1,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 4,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 2
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": true,
             "cost": 200000
         },
-		"extra": "N/A"
-	},
-	"713": {
-		"id": "713",
-		"charge": "Possession Of Deadly Weapons In A Correctional Facility",
-		"type": "F",
-		"class": {
-			"A": false,
-			"B": false,
-			"C": true
-		},
-		"offence": {
-			"1": true,
-			"2": false,
-			"3": false
-		},
-		"time": {
-			"days": 7,
-			"hours": 0,
-			"min": 0
-		},
-		"maxtime": {
-			"days": 9,
-			"hours": 0,
-			"min": 0
-		},
-		"points": {
-			"A": 0,
-			"B": 0,
-			"C": 4
-		},
-		"fine": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"impound": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
-		"suspension": {
-			"1": 0,
-			"2": 0,
-			"3": 0
-		},
+        "extra": "N/A"
+    },
+    "713": {
+        "id": "713",
+        "charge": "Possession Of Deadly Weapons In A Correctional Facility",
+        "definition": "(a) Any person, who knowingly brings or sends into, or knowingly assists in bringing into, or sending into, any detention facility as defined in the DCRA Act of 2023, any firearms, deadly weapons, explosives, tear gas or tear gas weapons, and any person who, while lawfully confined in a jail or county road camp possesses therein any firearm, deadly weapon, explosive, tear gas or tear gas weapon, is guilty of a felony.\n\n(b) Subdivision (a) shall not apply when otherwise authorized by law, or when authorized by the person in charge of the prison or other institution referred to in this section or by an officer of the institution empowered by the person in charge of the institution to give such authorization.",
+        "type": "F",
+        "class": {
+            "A": false,
+            "B": false,
+            "C": true
+        },
+        "offence": {
+            "1": true,
+            "2": false,
+            "3": false
+        },
+        "time": {
+            "days": 7,
+            "hours": 0,
+            "min": 0
+        },
+        "maxtime": {
+            "days": 9,
+            "hours": 0,
+            "min": 0
+        },
+        "points": {
+            "A": 0,
+            "B": 0,
+            "C": 4
+        },
+        "fine": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "impound": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
+        "suspension": {
+            "1": 0,
+            "2": 0,
+            "3": 0
+        },
         "bail": {
             "auto": 2,
             "cost": 500000
         },
-		"extra": "N/A"
-	}
+        "extra": "N/A"
+    }
 }


### PR DESCRIPTION
## Summary
- Populate definitions for all penal code entries using the official penal-code.txt source
- Reorder fields to maintain consistent structure across entries

## Testing
- `python - <<'PY'
import json
with open('json/gtaw_penal_code.json','r',encoding='utf-8') as f:
    data=json.load(f)
print('total codes', len(data))
missing=[k for k,v in data.items() if k!='000' and (not v.get('definition'))]
print('missing definitions', missing)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bac20a4a2c832a807ac6f0ef2474a5